### PR TITLE
fix: pin @astrojs/sitemap to 3.2.0 — 3.7.x regression breaks build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "robotregistryfoundation",
       "version": "1.7.0",
       "dependencies": {
-        "@astrojs/sitemap": "3.7.2",
+        "@astrojs/sitemap": "3.2.0",
         "@astrojs/tailwind": "^6.0.2",
         "astro": "^4.16.18",
         "nanoid": "^5.1.7",
@@ -82,14 +82,23 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
-      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.2.0.tgz",
+      "integrity": "sha512-SkrOCL3Z6HxdiXreZ1+aPBWgnBMJ31EgPdcscgQeLqI2Gqk/4EKLuw9q0SqKU9MmHpcPXXtcd0odfCk4barPoA==",
       "license": "MIT",
       "dependencies": {
-        "sitemap": "^9.0.0",
+        "sitemap": "^8.0.0",
         "stream-replace-string": "^2.0.0",
-        "zod": "^4.3.6"
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@astrojs/sitemap/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/tailwind": {
@@ -5462,23 +5471,29 @@
       "license": "MIT"
     },
     "node_modules/sitemap": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
-      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-8.0.3.tgz",
+      "integrity": "sha512-9Ew1tR2WYw8RGE2XLy7GjkusvYXy8Rg6y8TYuBuQMfIEdGcWoJpY2Wr5DzsEiL/TKCw56+YKTCCUHglorEYK+A==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^24.9.2",
+        "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
         "arg": "^5.0.0",
         "sax": "^1.4.1"
       },
       "bin": {
-        "sitemap": "dist/esm/cli.js"
+        "sitemap": "dist/cli.js"
       },
       "engines": {
-        "node": ">=20.19.5",
-        "npm": ">=10.8.2"
+        "node": ">=14.0.0",
+        "npm": ">=6.0.0"
       }
+    },
+    "node_modules/sitemap/node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -6236,6 +6251,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/sitemap": "3.7.2",
+    "@astrojs/sitemap": "3.2.0",
     "@astrojs/tailwind": "^6.0.2",
     "astro": "^4.16.18",
     "nanoid": "^5.1.7",


### PR DESCRIPTION
Dependabot bumped `@astrojs/sitemap` from 3.2.0 → 3.7.2, which introduced a regression that crashes builds when a content collection is empty (`Cannot read properties of undefined (reading 'reduce')`). Tracked upstream at withastro/astro#15894 — affects 3.7.1 and 3.7.2.

Pins back to `3.2.0` (last known good). No security CVEs associated with 3.7.x. Safe to pin until upstream publishes a fix.

Fixes the CI failure on main.