### PR TITLE
fix: upgrade yaml to 2.8.3 (CVE-2026-33532 DoS mitigation)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@astrojs/tailwind": "^6.0.2",
         "astro": "^4.16.18",
         "nanoid": "^5.1.7",
-        "tailwindcss": "^3.4.19"
+        "tailwindcss": "^3.4.19",
+        "yaml": "2.8.3"
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.19",
@@ -6211,9 +6212,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "robotregistryfoundation",
   "type": "module",
   "version": "1.7.0",
-  "description": "Robot Registry Foundation \u2014 Independent Infrastructure for Robot Identity",
+  "description": "Robot Registry Foundation — Independent Infrastructure for Robot Identity",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
@@ -15,7 +15,8 @@
     "@astrojs/tailwind": "^6.0.2",
     "astro": "^4.16.18",
     "nanoid": "^5.1.7",
-    "tailwindcss": "^3.4.19"
+    "tailwindcss": "^3.4.19",
+    "yaml": "2.8.3"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
## Summary

- Pins `yaml` to exactly `2.8.3` (was a transitive dependency at `2.8.2` via `astro`)
- Mitigates **CVE-2026-33532** — a denial-of-service vulnerability in the `yaml` package affecting versions prior to 2.8.3
- This is a safe patch-level upgrade; no API or behavior changes

## Changes

- `package.json`: adds `yaml` as an explicit dependency pinned to `2.8.3`
- `package-lock.json`: updated to reflect the pinned version

## Verification

- `npm install` completed cleanly
- `npm run build` (Astro static build) completed successfully — 12 pages built with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)