### PR TITLE
feat(rrf): tier-gated write-auth (Plan 1, RRF side — Tasks 1-9)

### DIFF
--- a/functions/v2/_lib/attestation-verify.test.ts
+++ b/functions/v2/_lib/attestation-verify.test.ts
@@ -148,4 +148,32 @@ describe("verifyAttestation", () => {
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.error).toMatch(/manifest|404/i);
   });
+
+  it("fail-never: bad pqPubB64 returns sig-verification-failed without throwing", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp);
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI,
+      pqPubB64: "!!!not-base64!!!",
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: okManifestFetch(RRN),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/sig/i);
+  });
+
+  it("rejects RURI manifest larger than 64 KiB (size cap)", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp);
+    const oversized = "x".repeat(70000);
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: vi.fn(async () => new Response(JSON.stringify({ rrn: RRN, pad: oversized }), { status: 200 })),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/too large/i);
+  });
 });

--- a/functions/v2/_lib/attestation-verify.test.ts
+++ b/functions/v2/_lib/attestation-verify.test.ts
@@ -1,0 +1,151 @@
+// functions/v2/_lib/attestation-verify.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { verifyAttestation } from "./attestation-verify.js";
+import { makeTestKeypair, signComplianceBody } from "./test-helpers.js";
+
+const RRN = "RRN-000000000042";
+const MODEL = "turtlebot3_burger";
+const RURI = "https://robotis.com";
+const NOW_MS = Date.parse("2026-04-25T00:00:00Z");
+
+function pubB64(kp: any): string {
+  return btoa(String.fromCharCode(...kp.mlDsa.publicKey));
+}
+
+async function buildAttestation(kp: any, overrides: Record<string, unknown> = {}) {
+  const body = {
+    rrn: RRN, manufacturer: "ROBOTIS", model: MODEL,
+    timestamp_iso: "2026-04-24T12:00:00Z",
+    ...overrides,
+  };
+  return await signComplianceBody(body, kp);
+}
+
+function okManifestFetch(rrn: string) {
+  return vi.fn(async () => new Response(JSON.stringify({ rrn }), { status: 200 }));
+}
+
+describe("verifyAttestation", () => {
+  it("accepts a valid attestation + matching RURI manifest", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp);
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: okManifestFetch(RRN),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.evidence.attestation_digest).toMatch(/^[0-9a-f]{64}$/);
+      expect(res.evidence.ruri_matched).toBe(`${RURI}/.well-known/rcan-manifest.json`);
+    }
+  });
+
+  it("rejects tampered attestation (sig no longer verifies)", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp);
+    // Tamper AFTER signing; sig now covers different bytes than the body.
+    (att as any).manufacturer = "evil-inc";
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: okManifestFetch(RRN),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/sig/i);
+  });
+
+  it("rejects when attestation.rrn does not match expectedRrn", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp, { rrn: "RRN-000000000999" });
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: okManifestFetch(RRN),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/rrn/i);
+  });
+
+  it("rejects when attestation.model does not match expectedModel", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp, { model: "some-other-model" });
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: okManifestFetch(RRN),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/model/i);
+  });
+
+  it("rejects an attestation older than 1 year", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp, { timestamp_iso: "2024-01-01T00:00:00Z" });
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: okManifestFetch(RRN),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/expire|stale|old/i);
+  });
+
+  it("rejects an attestation timestamped in the future (> 60s skew)", async () => {
+    const kp = await makeTestKeypair();
+    const futureIso = new Date(NOW_MS + 120_000).toISOString();
+    const att = await buildAttestation(kp, { timestamp_iso: futureIso });
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: okManifestFetch(RRN),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/future|skew/i);
+  });
+
+  it("rejects when RURI manifest is unreachable (fetch throws)", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp);
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: vi.fn(async () => { throw new TypeError("fetch failed"); }),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/unreachable/i);
+  });
+
+  it("rejects when RURI manifest rrn does not match", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp);
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: okManifestFetch("RRN-000000000999"),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/manifest/i);
+  });
+
+  it("rejects when RURI returns non-200", async () => {
+    const kp = await makeTestKeypair();
+    const att = await buildAttestation(kp);
+    const res = await verifyAttestation({
+      attestation: att as any, ruri: RURI, pqPubB64: pubB64(kp),
+      expectedRrn: RRN, expectedModel: MODEL,
+      fetchFn: vi.fn(async () => new Response("", { status: 404 })),
+      nowMs: NOW_MS,
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/manifest|404/i);
+  });
+});

--- a/functions/v2/_lib/attestation-verify.ts
+++ b/functions/v2/_lib/attestation-verify.ts
@@ -19,6 +19,7 @@ import { verifyBody } from "rcan-ts";
 
 const ONE_YEAR_MS = 365 * 24 * 3600 * 1000;
 const FUTURE_SKEW_MS = 60 * 1000;
+const MAX_MANIFEST_BYTES = 65536;
 
 export interface VerifyAttestationInput {
   attestation: Record<string, unknown>;
@@ -43,12 +44,13 @@ async function digestHex(bytes: Uint8Array): Promise<string> {
 }
 
 function canonicalCoreBytes(a: Record<string, unknown>): Uint8Array {
-  // Stable ordering, fixed field set — do not include sig/pq_kid/pq_signing_pub.
+  // Stable ordering, fixed field set — do not include sig/pq_signing_pub.
   const core = {
     rrn: a.rrn,
     manufacturer: a.manufacturer,
     model: a.model,
     timestamp_iso: a.timestamp_iso,
+    pq_kid: a.pq_kid,
   };
   return new TextEncoder().encode(JSON.stringify(core));
 }
@@ -82,7 +84,14 @@ export async function verifyAttestation(
   try {
     const res = await fetchFn(manifestUrl, { headers: { "Accept": "application/json" } });
     if (!res.ok) return { ok: false, error: `RURI manifest returned ${res.status}` };
+    const clHeader = res.headers.get("content-length");
+    if (clHeader && Number(clHeader) > MAX_MANIFEST_BYTES) {
+      return { ok: false, error: "RURI manifest too large" };
+    }
     manifestBody = await res.text();
+    if (manifestBody.length > MAX_MANIFEST_BYTES) {
+      return { ok: false, error: "RURI manifest too large" };
+    }
   } catch (e: any) {
     return { ok: false, error: `RURI unreachable: ${e?.message ?? "unknown"}` };
   }

--- a/functions/v2/_lib/attestation-verify.ts
+++ b/functions/v2/_lib/attestation-verify.ts
@@ -1,0 +1,97 @@
+/**
+ * Signed-attestation + RURI verifier for the manufacturer_verified tier.
+ *
+ * Given an attestation body (produced by the manufacturer via signBody over
+ * {rrn, manufacturer, model, timestamp_iso}) and the robot's registered
+ * pq_signing_pub, this verifier:
+ *   1. Cross-checks rrn/model against the robot's registered record.
+ *   2. Bounds the timestamp (1-year max age, 60s future skew cap).
+ *   3. Verifies the ML-DSA+Ed25519 hybrid signature.
+ *   4. Fetches ${ruri}/.well-known/rcan-manifest.json and confirms its rrn.
+ *
+ * Fail-never: every path returns VerifyAttestationOutcome.
+ *
+ * Evidence: SHA-256 hex digest of the canonical attestation core + the RURI
+ * manifest URL that matched. Intended for audit storage in identity_binding.
+ */
+
+import { verifyBody } from "rcan-ts";
+
+const ONE_YEAR_MS = 365 * 24 * 3600 * 1000;
+const FUTURE_SKEW_MS = 60 * 1000;
+
+export interface VerifyAttestationInput {
+  attestation: Record<string, unknown>;
+  ruri: string;
+  pqPubB64: string;
+  expectedRrn: string;
+  expectedModel: string;
+  fetchFn?: typeof fetch;
+  nowMs?: number;
+}
+
+export interface VerifyAttestationOk {
+  ok: true;
+  evidence: { attestation_digest: string; ruri_matched: string };
+}
+export interface VerifyAttestationErr { ok: false; error: string }
+export type VerifyAttestationOutcome = VerifyAttestationOk | VerifyAttestationErr;
+
+async function digestHex(bytes: Uint8Array): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", bytes as unknown as BufferSource);
+  return Array.from(new Uint8Array(hash)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function canonicalCoreBytes(a: Record<string, unknown>): Uint8Array {
+  // Stable ordering, fixed field set — do not include sig/pq_kid/pq_signing_pub.
+  const core = {
+    rrn: a.rrn,
+    manufacturer: a.manufacturer,
+    model: a.model,
+    timestamp_iso: a.timestamp_iso,
+  };
+  return new TextEncoder().encode(JSON.stringify(core));
+}
+
+export async function verifyAttestation(
+  input: VerifyAttestationInput,
+): Promise<VerifyAttestationOutcome> {
+  const { attestation, ruri, pqPubB64, expectedRrn, expectedModel } = input;
+  const fetchFn = input.fetchFn ?? fetch;
+  const now = input.nowMs ?? Date.now();
+
+  if (attestation.rrn !== expectedRrn) return { ok: false, error: "attestation rrn mismatch" };
+  if (attestation.model !== expectedModel) return { ok: false, error: "attestation model mismatch" };
+
+  const tsRaw = attestation.timestamp_iso;
+  if (typeof tsRaw !== "string") return { ok: false, error: "invalid timestamp_iso" };
+  const issued = Date.parse(tsRaw);
+  if (!Number.isFinite(issued)) return { ok: false, error: "invalid timestamp_iso" };
+  if (now - issued > ONE_YEAR_MS) return { ok: false, error: "attestation expired (> 1 year stale)" };
+  if (issued - now > FUTURE_SKEW_MS) return { ok: false, error: "attestation timestamp in the future (skew exceeds 60s)" };
+
+  let sigOk = false;
+  try {
+    const pqPub = Uint8Array.from(atob(pqPubB64), (c) => c.charCodeAt(0));
+    sigOk = await verifyBody(attestation, pqPub);
+  } catch { /* sigOk stays false */ }
+  if (!sigOk) return { ok: false, error: "attestation sig verification failed" };
+
+  const manifestUrl = `${ruri.replace(/\/+$/, "")}/.well-known/rcan-manifest.json`;
+  let manifestBody: string;
+  try {
+    const res = await fetchFn(manifestUrl, { headers: { "Accept": "application/json" } });
+    if (!res.ok) return { ok: false, error: `RURI manifest returned ${res.status}` };
+    manifestBody = await res.text();
+  } catch (e: any) {
+    return { ok: false, error: `RURI unreachable: ${e?.message ?? "unknown"}` };
+  }
+
+  let manifest: { rrn?: unknown };
+  try { manifest = JSON.parse(manifestBody); }
+  catch { return { ok: false, error: "RURI manifest is not valid JSON" }; }
+  if (manifest.rrn !== expectedRrn) return { ok: false, error: "RURI manifest rrn mismatch" };
+
+  const digest = await digestHex(canonicalCoreBytes(attestation));
+  return { ok: true, evidence: { attestation_digest: digest, ruri_matched: manifestUrl } };
+}

--- a/functions/v2/_lib/compliance-auth.test.ts
+++ b/functions/v2/_lib/compliance-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { verifyComplianceSubmission } from "./compliance-auth.js";
+import { verifyComplianceSubmission, verifyComplianceBody } from "./compliance-auth.js";
 import { signComplianceBody, makeTestKeypair, makeRobotRecord } from "./test-helpers.js";
 
 const RRN = "RRN-000000000001";
@@ -88,5 +88,18 @@ describe("verifyComplianceSubmission", () => {
     const tampered = { ...signed, rrn: "RRN-000000000999" };
     const result = await verifyComplianceSubmission(makePost(tampered), env, `robot:${RRN}`);
     expect(result).toEqual({ ok: false, status: 401, error: "Signature verification failed" });
+  });
+
+  it("rejects submission when entity is revoked (403)", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({
+      [`robot:${RRN}`]: makeRobotRecord(RRN, kp),
+      [`revocation:${RRN}`]: JSON.stringify({ revoked_at: "2026-04-24T00:00:00Z", reason: "test" }),
+    });
+    const doc = { schema: "rcan-fria-v1", rrn: RRN, generated_at: "x" };
+    const signed = await signComplianceBody(doc, kp);
+    const result = await verifyComplianceBody(signed, env, `robot:${RRN}`);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(403);
   });
 });

--- a/functions/v2/_lib/compliance-auth.ts
+++ b/functions/v2/_lib/compliance-auth.ts
@@ -10,6 +10,7 @@
  */
 
 import { verifyBody } from "rcan-ts";
+import { isRevoked } from "./revocation.js";
 
 export interface VerifiedSubmission {
   ok: true;
@@ -59,6 +60,11 @@ export async function verifyComplianceBody(
 
   const stored = await env.RRF_KV.get(entityKey, "text");
   if (!stored) return { ok: false, status: 401, error: "Robot not registered" };
+
+  const rrnMatch = entityKey.match(/^robot:(RRN-\d{12})$/);
+  if (rrnMatch && await isRevoked(env, rrnMatch[1])) {
+    return { ok: false, status: 403, error: "Entity key is revoked" };
+  }
 
   let record: Record<string, unknown>;
   try {

--- a/functions/v2/_lib/dns-verify.test.ts
+++ b/functions/v2/_lib/dns-verify.test.ts
@@ -1,0 +1,87 @@
+// functions/v2/_lib/dns-verify.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { verifyDnsTxt } from "./dns-verify.js";
+
+const RRN = "RRN-000000000042";
+const MODEL = "turtlebot3_burger";
+const DOMAIN = "robotis.com";
+const EXPECTED_TXT = `rrn=${RRN};model=${MODEL}`;
+
+function dohAnswer(txts: string[], status = 0) {
+  return new Response(
+    JSON.stringify({
+      Status: status,
+      Answer: txts.map((t) => ({ name: `_rcan-verify.${DOMAIN}`, type: 16, TTL: 60, data: `"${t}"` })),
+    }),
+    { status: 200, headers: { "Content-Type": "application/dns-json" } },
+  );
+}
+
+describe("verifyDnsTxt", () => {
+  it("accepts a valid TXT record matching rrn;model", async () => {
+    const fetchFn = vi.fn(async () => dohAnswer([EXPECTED_TXT]));
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.evidence).toBe(EXPECTED_TXT);
+    // Sanity: fetch URL must include the DoH host and TXT type.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const url = (fetchFn.mock.calls[0]?.[0] as string) ?? "";
+    expect(url).toMatch(/^https:\/\/cloudflare-dns\.com\/dns-query\?/);
+    expect(url).toContain(`name=_rcan-verify.${DOMAIN}`);
+    expect(url).toContain("type=TXT");
+  });
+
+  it("returns error when no TXT record exists (empty Answer, Status=0)", async () => {
+    const fetchFn = vi.fn(async () => new Response(
+      JSON.stringify({ Status: 0 }),
+      { status: 200, headers: { "Content-Type": "application/dns-json" } },
+    ));
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(false);
+  });
+
+  it("returns error when TXT exists but rrn field does not match", async () => {
+    const wrongRrn = `rrn=RRN-000000000999;model=${MODEL}`;
+    const fetchFn = vi.fn(async () => dohAnswer([wrongRrn]));
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(false);
+  });
+
+  it("returns error when TXT exists but model field does not match", async () => {
+    const wrongModel = `rrn=${RRN};model=some-other-model`;
+    const fetchFn = vi.fn(async () => dohAnswer([wrongModel]));
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts when multiple TXT records are returned and one matches", async () => {
+    const fetchFn = vi.fn(async () => dohAnswer([
+      "rrn=RRN-000000000999;model=other-model",
+      "some-unrelated=record",
+      EXPECTED_TXT,
+    ]));
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.evidence).toBe(EXPECTED_TXT);
+  });
+
+  it("returns error on DoH 5xx (never throws)", async () => {
+    const fetchFn = vi.fn(async () => new Response("server error", { status: 503 }));
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(false);
+  });
+
+  it("returns error on network failure (fetch throws, never rethrown)", async () => {
+    const fetchFn = vi.fn(async () => { throw new TypeError("fetch failed"); });
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects domain with newline injection attempt", async () => {
+    const fetchFn = vi.fn();
+    const res = await verifyDnsTxt("evil.com\nattacker.com", RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(false);
+    // Critically, the verifier must NOT attempt the DoH request with a bogus domain.
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});

--- a/functions/v2/_lib/dns-verify.test.ts
+++ b/functions/v2/_lib/dns-verify.test.ts
@@ -29,6 +29,9 @@ describe("verifyDnsTxt", () => {
     expect(url).toMatch(/^https:\/\/cloudflare-dns\.com\/dns-query\?/);
     expect(url).toContain(`name=_rcan-verify.${DOMAIN}`);
     expect(url).toContain("type=TXT");
+    // Assert Accept header was set.
+    const opts = fetchFn.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect((opts?.headers as Record<string, string> | undefined)?.Accept).toBe("application/dns-json");
   });
 
   it("returns error when no TXT record exists (empty Answer, Status=0)", async () => {
@@ -83,5 +86,33 @@ describe("verifyDnsTxt", () => {
     expect(res.ok).toBe(false);
     // Critically, the verifier must NOT attempt the DoH request with a bogus domain.
     expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("accepts multi-string TXT (data field contains multiple quoted runs)", async () => {
+    // DoH represents multi-string TXT as "run1" "run2" in a single data field.
+    // Simulate a long payload split across two runs.
+    const firstHalf = `rrn=${RRN};model=`;
+    const secondHalf = MODEL;
+    const multiString = `"${firstHalf}" "${secondHalf}"`;
+    const fetchFn = vi.fn(async () => new Response(
+      JSON.stringify({
+        Status: 0,
+        Answer: [{ name: `_rcan-verify.${DOMAIN}`, type: 16, TTL: 60, data: multiString }],
+      }),
+      { status: 200 },
+    ));
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, fetchFn);
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.evidence).toBe(EXPECTED_TXT);
+  });
+
+  it("falls back to global fetch when fetchFn is undefined", async () => {
+    const spy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ Status: 0, Answer: [] }), { status: 200 })
+    );
+    const res = await verifyDnsTxt(DOMAIN, RRN, MODEL, undefined);
+    expect(spy).toHaveBeenCalled();
+    expect(res.ok).toBe(false);  // empty Answer → not-found, but fetch was called
+    spy.mockRestore();
   });
 });

--- a/functions/v2/_lib/dns-verify.ts
+++ b/functions/v2/_lib/dns-verify.ts
@@ -21,6 +21,9 @@ export interface VerifyDnsTxtError { ok: false; error: string }
 export type VerifyDnsTxtOutcome = VerifyDnsTxtResult | VerifyDnsTxtError;
 
 const DOH_ENDPOINT = "https://cloudflare-dns.com/dns-query";
+// Belt-and-suspenders. The real defense is encodeURIComponent on the DoH
+// query name below; this regex rejects obviously malformed domains early
+// (before paying for a round-trip) and gives a clear `Invalid domain` error.
 const INVALID_DOMAIN_CHARS = /[\s;\x00-\x1f\x7f]/;
 
 function isValidDomain(domain: string): boolean {
@@ -33,14 +36,24 @@ function isValidDomain(domain: string): boolean {
 interface DohAnswer { name?: string; type?: number; TTL?: number; data?: string }
 interface DohResponse { Status?: number; Answer?: DohAnswer[] }
 
-function stripTxtQuotes(raw: string): string {
-  // DoH JSON wraps TXT data in surrounding double quotes. Strip once.
-  if (raw.length >= 2 && raw[0] === '"' && raw[raw.length - 1] === '"') {
-    return raw.slice(1, -1);
-  }
-  return raw;
+/**
+ * Decode Cloudflare DoH JSON TXT `data`. A single-string TXT is wrapped in one
+ * pair of double quotes (`"payload"`). A multi-string TXT is rendered as
+ * multiple quoted runs, e.g. `"part1" "part2"` — DNS splits strings longer
+ * than 255 bytes. We concatenate all quoted runs (unquoted) into a single
+ * payload. If the data doesn't match any quoted-run shape, return it as-is
+ * (defensive; lets exact-match fail rather than mis-decode).
+ */
+function decodeTxtData(raw: string): string {
+  const runs = raw.match(/"([^"]*)"/g);
+  if (!runs || runs.length === 0) return raw;
+  return runs.map((r) => r.slice(1, -1)).join("");
 }
 
+/**
+ * Verify a manufacturer domain using DNS TXT lookup.
+ * Field order is fixed: `rrn=...;model=...`. Reversed ordering is rejected.
+ */
 export async function verifyDnsTxt(
   domain: string,
   expectedRrn: string,
@@ -70,14 +83,17 @@ export async function verifyDnsTxt(
     return { ok: false, error: "DoH response was not valid JSON" };
   }
 
-  if (doh.Status !== 0 || !Array.isArray(doh.Answer) || doh.Answer.length === 0) {
+  if (doh.Status !== 0) {
+    return { ok: false, error: `DoH returned Status=${doh.Status}` };
+  }
+  if (!Array.isArray(doh.Answer) || doh.Answer.length === 0) {
     return { ok: false, error: "No TXT record" };
   }
 
   const expected = `rrn=${expectedRrn};model=${expectedModel}`;
   for (const answer of doh.Answer) {
     if (answer.type !== 16 || typeof answer.data !== "string") continue;
-    const raw = stripTxtQuotes(answer.data);
+    const raw = decodeTxtData(answer.data);
     if (raw === expected) return { ok: true, evidence: raw };
   }
 

--- a/functions/v2/_lib/dns-verify.ts
+++ b/functions/v2/_lib/dns-verify.ts
@@ -1,0 +1,85 @@
+// functions/v2/_lib/dns-verify.ts
+/**
+ * Server-side DoH-based DNS TXT verifier for the manufacturer_claimed tier.
+ *
+ * Looks up `_rcan-verify.<domain>` via Cloudflare's DoH endpoint and confirms
+ * there is a TXT record of the form `rrn=<rrn>;model=<model>`. The expected
+ * format is defined in rcan-spec/docs/verification/manufacturer-verification.md.
+ *
+ * The verifier:
+ *   - Validates `domain` to prevent DoH query injection (no whitespace, no
+ *     semicolons, no leading/trailing dots).
+ *   - Uses a caller-injectable `fetchFn` for testability.
+ *   - Never throws: any DoH non-2xx / network error returns {ok:false, error:...}.
+ *
+ * The lookup is authoritative for the moment of verification only (one-shot).
+ * Long-lived re-verification is a future task.
+ */
+
+export interface VerifyDnsTxtResult { ok: true; evidence: string }
+export interface VerifyDnsTxtError { ok: false; error: string }
+export type VerifyDnsTxtOutcome = VerifyDnsTxtResult | VerifyDnsTxtError;
+
+const DOH_ENDPOINT = "https://cloudflare-dns.com/dns-query";
+const INVALID_DOMAIN_CHARS = /[\s;\x00-\x1f\x7f]/;
+
+function isValidDomain(domain: string): boolean {
+  if (typeof domain !== "string" || domain.length === 0 || domain.length > 253) return false;
+  if (INVALID_DOMAIN_CHARS.test(domain)) return false;
+  if (domain.startsWith(".") || domain.endsWith(".")) return false;
+  return true;
+}
+
+interface DohAnswer { name?: string; type?: number; TTL?: number; data?: string }
+interface DohResponse { Status?: number; Answer?: DohAnswer[] }
+
+function stripTxtQuotes(raw: string): string {
+  // DoH JSON wraps TXT data in surrounding double quotes. Strip once.
+  if (raw.length >= 2 && raw[0] === '"' && raw[raw.length - 1] === '"') {
+    return raw.slice(1, -1);
+  }
+  return raw;
+}
+
+export async function verifyDnsTxt(
+  domain: string,
+  expectedRrn: string,
+  expectedModel: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<VerifyDnsTxtOutcome> {
+  if (!isValidDomain(domain)) return { ok: false, error: "Invalid domain" };
+
+  const name = `_rcan-verify.${domain}`;
+  const url = `${DOH_ENDPOINT}?name=${encodeURIComponent(name)}&type=TXT`;
+
+  let response: Response;
+  try {
+    response = await fetchFn(url, { headers: { "Accept": "application/dns-json" } });
+  } catch (e: any) {
+    return { ok: false, error: `DoH unreachable: ${e?.message ?? "unknown"}` };
+  }
+
+  if (!response.ok) {
+    return { ok: false, error: `DoH returned ${response.status}` };
+  }
+
+  let doh: DohResponse;
+  try {
+    doh = (await response.json()) as DohResponse;
+  } catch {
+    return { ok: false, error: "DoH response was not valid JSON" };
+  }
+
+  if (doh.Status !== 0 || !Array.isArray(doh.Answer) || doh.Answer.length === 0) {
+    return { ok: false, error: "No TXT record" };
+  }
+
+  const expected = `rrn=${expectedRrn};model=${expectedModel}`;
+  for (const answer of doh.Answer) {
+    if (answer.type !== 16 || typeof answer.data !== "string") continue;
+    const raw = stripTxtQuotes(answer.data);
+    if (raw === expected) return { ok: true, evidence: raw };
+  }
+
+  return { ok: false, error: "TXT record format did not match" };
+}

--- a/functions/v2/_lib/redact.test.ts
+++ b/functions/v2/_lib/redact.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { redactRobotRecord } from "./redact.js";
+
+describe("redactRobotRecord", () => {
+  it("strips api_key", () => {
+    const input = { rrn: "RRN-000000000001", api_key: "secret", name: "bob" };
+    expect(redactRobotRecord(input)).toEqual({ rrn: "RRN-000000000001", name: "bob" });
+  });
+
+  it("returns a new object (does not mutate input)", () => {
+    const input = { rrn: "RRN-000000000001", api_key: "secret" };
+    redactRobotRecord(input);
+    expect(input.api_key).toBe("secret");
+  });
+
+  it("handles records without api_key (no-op)", () => {
+    const input = { rrn: "RRN-000000000001", name: "bob" };
+    expect(redactRobotRecord(input)).toEqual(input);
+  });
+});

--- a/functions/v2/_lib/redact.ts
+++ b/functions/v2/_lib/redact.ts
@@ -1,0 +1,16 @@
+/**
+ * Record-redaction helper.
+ *
+ * The stored robot record includes fields that are secrets or server-internal
+ * (notably `api_key` — a bearer token used for PATCH/DELETE authentication).
+ * Responses that echo the record must strip these before returning, especially
+ * for endpoints reachable without auth (GET).
+ *
+ * Do NOT use this on the object that gets written to KV — only on the object
+ * that goes into the HTTP response body.
+ */
+export function redactRobotRecord<T extends Record<string, unknown>>(record: T): Omit<T, "api_key"> {
+  const { api_key, ...rest } = record as T & { api_key?: unknown };
+  void api_key;
+  return rest as Omit<T, "api_key">;
+}

--- a/functions/v2/_lib/revocation.test.ts
+++ b/functions/v2/_lib/revocation.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+import { isRevoked, markRevoked } from "./revocation.js";
+
+const RRN = "RRN-000000000042";
+
+function makeEnv() {
+  const store: Record<string, string> = {};
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+      delete: vi.fn(async (k: string) => { delete store[k]; }),
+      list: vi.fn(),
+    } as unknown as KVNamespace,
+    __store: store,
+  };
+}
+
+describe("revocation helper", () => {
+  it("isRevoked returns false when no revocation entry", async () => {
+    const env = makeEnv();
+    expect(await isRevoked(env, RRN)).toBe(false);
+  });
+
+  it("markRevoked writes a revocation entry that isRevoked observes", async () => {
+    const env = makeEnv();
+    await markRevoked(env, RRN, "operator request");
+    expect(await isRevoked(env, RRN)).toBe(true);
+    const raw = JSON.parse(env.__store[`revocation:${RRN}`]);
+    expect(raw.reason).toBe("operator request");
+    expect(raw.revoked_at).toBeTypeOf("string");
+  });
+
+  it("isRevoked tolerates malformed revocation blobs (treat as revoked)", async () => {
+    const env = makeEnv();
+    env.__store[`revocation:${RRN}`] = "not-json";
+    expect(await isRevoked(env, RRN)).toBe(true);
+  });
+});

--- a/functions/v2/_lib/revocation.ts
+++ b/functions/v2/_lib/revocation.ts
@@ -1,0 +1,11 @@
+export interface RevocationEnv { RRF_KV: KVNamespace }
+
+export async function isRevoked(env: RevocationEnv, rrn: string): Promise<boolean> {
+  const raw = await env.RRF_KV.get(`revocation:${rrn}`, "text");
+  return raw !== null;  // presence = revoked, regardless of content parseability
+}
+
+export async function markRevoked(env: RevocationEnv, rrn: string, reason: string): Promise<void> {
+  const entry = { revoked_at: new Date().toISOString(), reason };
+  await env.RRF_KV.put(`revocation:${rrn}`, JSON.stringify(entry));
+}

--- a/functions/v2/robots/[rrn]/index.test.ts
+++ b/functions/v2/robots/[rrn]/index.test.ts
@@ -163,6 +163,14 @@ describe("GET /v2/robots/[rrn]", () => {
     expect(json.revoked).toBeUndefined();
     expect(json.revoked_at).toBeUndefined();
   });
+
+  it("GET response body does not include api_key", async () => {
+    const env = makeEnv();
+    const res = await onRequestGet({ env, params: { rrn: RRN } } as any);
+    const body = await res.json();
+    expect(body.api_key).toBeUndefined();
+    expect(env.__store[`robot:${RRN}`]).toContain(API_KEY);  // still in KV
+  });
 });
 
 describe("DELETE /v2/robots/[rrn]", () => {
@@ -373,6 +381,7 @@ describe("PATCH /v2/robots/[rrn] — happy path (real sig verify)", () => {
     expect(updated.pq_signing_pub).toBe(patchFx.pq_signing_pub);
     expect(updated.pq_kid).toBe(patchFx.pq_kid);
     expect(updated.updated_at).toBeDefined();
+    expect(updated.api_key).toBeUndefined();
   });
 
   it("rejects a PATCH with tampered ml_dsa signature (400)", async () => {

--- a/functions/v2/robots/[rrn]/index.test.ts
+++ b/functions/v2/robots/[rrn]/index.test.ts
@@ -106,6 +106,16 @@ describe("PATCH /v2/robots/[rrn]", () => {
     } as any);
     expect(res.status).toBe(400);
   });
+
+  it("returns 403 when record is revoked", async () => {
+    const env = makeEnv();
+    env.__store[`revocation:${RRN}`] = JSON.stringify({ revoked_at: "2026-04-24T00:00:00Z", reason: "test" });
+    const res = await onRequestPatch({
+      request: makePatchRequest(STUB_PATCH_BODY),
+      env, params: { rrn: RRN },
+    } as any);
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("GET /v2/robots/[rrn]", () => {
@@ -121,6 +131,25 @@ describe("GET /v2/robots/[rrn]", () => {
     const env = makeEnv(null);
     const res = await onRequestGet({ env, params: { rrn: RRN } } as any);
     expect(res.status).toBe(404);
+  });
+
+  it("surfaces revoked flag + revoked_at when a revocation entry exists", async () => {
+    const env = makeEnv();
+    env.__store[`revocation:${RRN}`] = JSON.stringify({ revoked_at: "2026-04-24T00:00:00Z", reason: "test" });
+    const res = await onRequestGet({ env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.revoked).toBe(true);
+    expect(json.revoked_at).toBe("2026-04-24T00:00:00Z");
+  });
+
+  it("omits revoked flag when no revocation entry", async () => {
+    const env = makeEnv();
+    const res = await onRequestGet({ env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.revoked).toBeUndefined();
+    expect(json.revoked_at).toBeUndefined();
   });
 });
 

--- a/functions/v2/robots/[rrn]/index.test.ts
+++ b/functions/v2/robots/[rrn]/index.test.ts
@@ -116,6 +116,18 @@ describe("PATCH /v2/robots/[rrn]", () => {
     } as any);
     expect(res.status).toBe(403);
   });
+
+  it("revocation short-circuits before api_key check (error message proves ordering)", async () => {
+    const env = makeEnv();
+    env.__store[`revocation:${RRN}`] = JSON.stringify({ revoked_at: "2026-04-24T00:00:00Z", reason: "test" });
+    const res = await onRequestPatch({
+      request: makePatchRequest(STUB_PATCH_BODY, "wrong-api-key"),  // wrong key AND revoked — revocation must win
+      env, params: { rrn: RRN },
+    } as any);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Record is revoked");
+  });
 });
 
 describe("GET /v2/robots/[rrn]", () => {

--- a/functions/v2/robots/[rrn]/index.ts
+++ b/functions/v2/robots/[rrn]/index.ts
@@ -8,6 +8,7 @@
  */
 
 import { isValidId } from "../../_lib/id.js";
+import { isRevoked } from "../../_lib/revocation.js";
 import { verifyBody } from "rcan-ts";
 
 export interface Env { RRF_KV: KVNamespace }
@@ -42,7 +43,19 @@ export const onRequestGet: PagesFunction<Env> = async ({ env, params }) => {
     });
   }
 
-  return new Response(stored, {
+  const parsed = JSON.parse(stored);
+  const revRaw = await env.RRF_KV.get(`revocation:${rrn}`, "text");
+  if (revRaw !== null) {
+    try {
+      const rev = JSON.parse(revRaw);
+      parsed.revoked = true;
+      if (typeof rev.revoked_at === "string") parsed.revoked_at = rev.revoked_at;
+    } catch {
+      parsed.revoked = true;  // malformed blob → fail-closed, still mark revoked
+    }
+  }
+
+  return new Response(JSON.stringify(parsed), {
     headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=60" },
   });
 };
@@ -56,6 +69,9 @@ export const onRequestPatch: PagesFunction<Env> = async ({ request, env, params 
   const raw = await env.RRF_KV.get(`robot:${rrn}`, "text");
   if (!raw) return err("Not found", 404);
   const record = JSON.parse(raw);
+
+  if (await isRevoked(env, rrn)) return err("Record is revoked", 403);
+
   if (record.api_key !== apiKey) return err("Unauthorized", 403);
 
   let body: Record<string, unknown>;

--- a/functions/v2/robots/[rrn]/index.ts
+++ b/functions/v2/robots/[rrn]/index.ts
@@ -10,6 +10,7 @@
 import { isValidId } from "../../_lib/id.js";
 import { isRevoked } from "../../_lib/revocation.js";
 import { verifyBody } from "rcan-ts";
+import { redactRobotRecord } from "../../_lib/redact.js";
 
 export interface Env { RRF_KV: KVNamespace }
 
@@ -58,7 +59,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ env, params }) => {
     }
   }
 
-  return new Response(JSON.stringify(parsed), {
+  return new Response(JSON.stringify(redactRobotRecord(parsed)), {
     headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=60" },
   });
 };
@@ -117,7 +118,7 @@ async function handleSigningKeyUpgrade(
   record.pq_kid = pq_kid;
   record.updated_at = new Date().toISOString();
   await env.RRF_KV.put(`robot:${rrn}`, JSON.stringify(record));
-  return ok(record);
+  return ok(redactRobotRecord(record));
 }
 
 async function handleFieldUpdate(
@@ -144,7 +145,7 @@ async function handleFieldUpdate(
   }
   record.updated_at = new Date().toISOString();
   await env.RRF_KV.put(`robot:${rrn}`, JSON.stringify(record));
-  return ok(record);
+  return ok(redactRobotRecord(record));
 }
 
 export const onRequestDelete: PagesFunction<Env> = async ({ request, env, params }) => {

--- a/functions/v2/robots/[rrn]/index.ts
+++ b/functions/v2/robots/[rrn]/index.ts
@@ -36,7 +36,11 @@ export const onRequestGet: PagesFunction<Env> = async ({ env, params }) => {
     });
   }
 
-  const stored = await env.RRF_KV.get(`robot:${rrn}`, "text");
+  const [stored, revRaw] = await Promise.all([
+    env.RRF_KV.get(`robot:${rrn}`, "text"),
+    env.RRF_KV.get(`revocation:${rrn}`, "text"),
+  ]);
+
   if (!stored) {
     return new Response(JSON.stringify({ error: "Robot not found", rrn }), {
       status: 404, headers: { "Content-Type": "application/json" },
@@ -44,7 +48,6 @@ export const onRequestGet: PagesFunction<Env> = async ({ env, params }) => {
   }
 
   const parsed = JSON.parse(stored);
-  const revRaw = await env.RRF_KV.get(`revocation:${rrn}`, "text");
   if (revRaw !== null) {
     try {
       const rev = JSON.parse(revRaw);

--- a/functions/v2/robots/[rrn]/revoke-key.test.ts
+++ b/functions/v2/robots/[rrn]/revoke-key.test.ts
@@ -77,6 +77,22 @@ describe("POST /v2/robots/[rrn]/revoke-key", () => {
     expect(res.status).toBe(400);
   });
 
+  it("400 when body.action is not 'revoke'", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, kp) });
+    const signed = await signComplianceBody({ rrn: RRN, action: "delete" }, kp);
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when reason is present but not a string", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, kp) });
+    const signed = await signComplianceBody({ rrn: RRN, action: "revoke", reason: 42 }, kp);
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(400);
+  });
+
   it("409 when already revoked", async () => {
     const kp = await makeTestKeypair();
     const env = makeEnv({

--- a/functions/v2/robots/[rrn]/revoke-key.test.ts
+++ b/functions/v2/robots/[rrn]/revoke-key.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from "vitest";
+import { onRequestPost } from "./revoke-key.js";
+import { makeTestKeypair, makeRobotRecord, signComplianceBody } from "../../_lib/test-helpers.js";
+
+const RRN = "RRN-000000000042";
+
+function makeEnv(init: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...init };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+      delete: vi.fn(async (k: string) => { delete store[k]; }),
+      list: vi.fn(),
+    } as unknown as KVNamespace,
+    __store: store,
+  };
+}
+
+function req(body: unknown): Request {
+  return new Request(`https://x/v2/robots/${RRN}/revoke-key`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /v2/robots/[rrn]/revoke-key", () => {
+  it("400 on invalid RRN format", async () => {
+    const env = makeEnv();
+    const res = await onRequestPost({ request: req({}), env, params: { rrn: "bad" } } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when record does not exist", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv();
+    const signed = await signComplianceBody({ rrn: RRN, action: "revoke", reason: "lost laptop" }, kp);
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(404);
+  });
+
+  it("revokes with valid signature (204) and writes revocation entry", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, kp) });
+    const signed = await signComplianceBody({ rrn: RRN, action: "revoke", reason: "lost laptop" }, kp);
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(204);
+    const rev = JSON.parse(env.__store[`revocation:${RRN}`]);
+    expect(rev.reason).toBe("lost laptop");
+    expect(rev.revoked_at).toBeTypeOf("string");
+  });
+
+  it("rejects signature from a non-current key (401)", async () => {
+    const kp1 = await makeTestKeypair();
+    const kp2 = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, kp1) });
+    const signed = await signComplianceBody({ rrn: RRN, action: "revoke" }, kp2);
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects tampered body (401)", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, kp) });
+    const signed = await signComplianceBody({ rrn: RRN, action: "revoke" }, kp);
+    const tampered = { ...signed, action: "keep" };
+    const res = await onRequestPost({ request: req(tampered), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(401);
+  });
+
+  it("400 when body does not bind rrn and action:revoke", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, kp) });
+    const signed = await signComplianceBody({ rrn: "RRN-000000000999", action: "revoke" }, kp);
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("409 when already revoked", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({
+      [`robot:${RRN}`]: makeRobotRecord(RRN, kp),
+      [`revocation:${RRN}`]: JSON.stringify({ revoked_at: "2026-04-24T00:00:00Z", reason: "first" }),
+    });
+    const signed = await signComplianceBody({ rrn: RRN, action: "revoke", reason: "second" }, kp);
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(409);
+  });
+});

--- a/functions/v2/robots/[rrn]/revoke-key.ts
+++ b/functions/v2/robots/[rrn]/revoke-key.ts
@@ -1,0 +1,45 @@
+import { isValidId } from "../../_lib/id.js";
+import { verifyBody } from "rcan-ts";
+import { isRevoked, markRevoked } from "../../_lib/revocation.js";
+
+export interface Env { RRF_KV: KVNamespace }
+
+function err(msg: string, status: number): Response {
+  return new Response(JSON.stringify({ error: msg }), {
+    status, headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env, params }) => {
+  const rrn = params.rrn as string;
+  if (!isValidId(rrn, "RRN")) return err("Invalid RRN format", 400);
+
+  let body: Record<string, unknown>;
+  try { body = await request.json() as Record<string, unknown>; }
+  catch { return err("Invalid JSON body", 400); }
+
+  const stored = await env.RRF_KV.get(`robot:${rrn}`, "text");
+  if (!stored) return err("Not found", 404);
+  const record = JSON.parse(stored);
+
+  const pqPubB64 = record.pq_signing_pub;
+  if (typeof pqPubB64 !== "string") return err("Record has no registered key", 400);
+
+  // Verify signature BEFORE checking action binding, so tampering is caught as 401 not 400
+  let verified = false;
+  try {
+    const pqPub = Uint8Array.from(atob(pqPubB64), c => c.charCodeAt(0));
+    verified = await verifyBody(body, pqPub);
+  } catch { /* verified stays false */ }
+  if (!verified) return err("Signature verification failed", 401);
+
+  if (body.rrn !== rrn || body.action !== "revoke") {
+    return err("Body must bind rrn and action:revoke", 400);
+  }
+
+  if (await isRevoked(env, rrn)) return err("Already revoked", 409);
+
+  const reason = typeof body.reason === "string" ? body.reason : "unspecified";
+  await markRevoked(env, rrn, reason);
+  return new Response(null, { status: 204 });
+};

--- a/functions/v2/robots/[rrn]/revoke-key.ts
+++ b/functions/v2/robots/[rrn]/revoke-key.ts
@@ -37,6 +37,10 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env, params }
     return err("Body must bind rrn and action:revoke", 400);
   }
 
+  if (body.reason !== undefined && typeof body.reason !== "string") {
+    return err("reason must be a string if provided", 400);
+  }
+
   if (await isRevoked(env, rrn)) return err("Already revoked", 409);
 
   const reason = typeof body.reason === "string" ? body.reason : "unspecified";

--- a/functions/v2/robots/[rrn]/rotate-key.test.ts
+++ b/functions/v2/robots/[rrn]/rotate-key.test.ts
@@ -177,6 +177,7 @@ describe("POST /v2/robots/[rrn]/rotate-key", () => {
     expect(updated.rotations).toHaveLength(1);
     expect(updated.rotations[0].new_pq_kid).toBe("testkid-new");
     expect(updated.updated_at).toBeTypeOf("string");
+    expect(updated.api_key).toBeUndefined();
   });
 
   it("appends (not overwrites) rotations[] across multiple rotations", async () => {

--- a/functions/v2/robots/[rrn]/rotate-key.test.ts
+++ b/functions/v2/robots/[rrn]/rotate-key.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi } from "vitest";
+import { onRequestPost } from "./rotate-key.js";
+import { makeTestKeypair, makeRobotRecord, signComplianceBody, type TestKeypair } from "../../_lib/test-helpers.js";
+
+const RRN = "RRN-000000000042";
+
+function makeEnv(init: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...init };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+      delete: vi.fn(async (k: string) => { delete store[k]; }),
+      list: vi.fn(),
+    } as unknown as KVNamespace,
+    __store: store,
+  };
+}
+
+function req(body: unknown, urlRrn: string = RRN): Request {
+  return new Request(`https://x/v2/robots/${urlRrn}/rotate-key`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function buildRotateRequest(oldKp: TestKeypair, newKp: TestKeypair, urlRrn: string = RRN) {
+  // Canonical body each signer commits to (before signBody adds pq_signing_pub / pq_kid).
+  // Sign TWICE with the SAME canonical doc; each signer contributes their own identity fields.
+  const canonical = {
+    rrn: urlRrn,
+    action: "rotate" as const,
+    new_pq_signing_pub: btoa(String.fromCharCode(...newKp.mlDsa.publicKey)),
+    new_pq_kid: "testkid-new",  // signer-picked label; server does not verify this matches anything.
+  };
+  const by_old_key = await signComplianceBody(canonical, oldKp);
+  const by_new_key = await signComplianceBody(canonical, newKp);
+  return { by_old_key, by_new_key };
+}
+
+describe("POST /v2/robots/[rrn]/rotate-key", () => {
+  it("400 on invalid RRN format", async () => {
+    const env = makeEnv();
+    const res = await onRequestPost({ request: req({}, "bad"), env, params: { rrn: "bad" } } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("404 when record does not exist", async () => {
+    const oldKp = await makeTestKeypair();
+    const newKp = await makeTestKeypair();
+    const env = makeEnv();
+    const body = await buildRotateRequest(oldKp, newKp);
+    const res = await onRequestPost({ request: req(body), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(404);
+  });
+
+  it("403 when record is revoked", async () => {
+    const oldKp = await makeTestKeypair();
+    const newKp = await makeTestKeypair();
+    const env = makeEnv({
+      [`robot:${RRN}`]: makeRobotRecord(RRN, oldKp),
+      [`revocation:${RRN}`]: JSON.stringify({ revoked_at: "2026-04-24T00:00:00Z", reason: "test" }),
+    });
+    const body = await buildRotateRequest(oldKp, newKp);
+    const res = await onRequestPost({ request: req(body), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(403);
+  });
+
+  it("400 when envelopes disagree on new_pq_signing_pub", async () => {
+    const oldKp = await makeTestKeypair();
+    const newKp = await makeTestKeypair();
+    const otherKp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, oldKp) });
+    const by_old_key = await signComplianceBody({
+      rrn: RRN, action: "rotate",
+      new_pq_signing_pub: btoa(String.fromCharCode(...newKp.mlDsa.publicKey)),
+      new_pq_kid: "testkid-new",
+    }, oldKp);
+    const by_new_key = await signComplianceBody({
+      rrn: RRN, action: "rotate",
+      new_pq_signing_pub: btoa(String.fromCharCode(...otherKp.mlDsa.publicKey)),  // DIFFERENT
+      new_pq_kid: "testkid-new",
+    }, otherKp);
+    const res = await onRequestPost({ request: req({ by_old_key, by_new_key }), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when new_pq_signing_pub equals current record key", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, kp) });
+    const body = await buildRotateRequest(kp, kp);
+    const res = await onRequestPost({ request: req(body), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("401 when by_old_key is signed by a non-current key", async () => {
+    const realCurrent = await makeTestKeypair();
+    const attackerKp = await makeTestKeypair();
+    const newKp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, realCurrent) });
+    const body = await buildRotateRequest(attackerKp, newKp);  // by_old_key signed by attacker, not realCurrent
+    const res = await onRequestPost({ request: req(body), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(401);
+  });
+
+  it("401 when by_new_key is signed by something other than the declared new key", async () => {
+    const oldKp = await makeTestKeypair();
+    const newKp = await makeTestKeypair();
+    const otherKp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, oldKp) });
+    const by_old_key = await signComplianceBody({
+      rrn: RRN, action: "rotate",
+      new_pq_signing_pub: btoa(String.fromCharCode(...newKp.mlDsa.publicKey)),
+      new_pq_kid: "testkid-new",
+    }, oldKp);
+    // by_new_key declares newKp but is actually signed by otherKp — signComplianceBody will stamp
+    // otherKp's pq_signing_pub into the envelope, which won't equal the declared new_pq_signing_pub.
+    const by_new_key = await signComplianceBody({
+      rrn: RRN, action: "rotate",
+      new_pq_signing_pub: btoa(String.fromCharCode(...newKp.mlDsa.publicKey)),
+      new_pq_kid: "testkid-new",
+    }, otherKp);
+    const res = await onRequestPost({ request: req({ by_old_key, by_new_key }), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(401);
+  });
+
+  it("400 when either envelope is missing", async () => {
+    const oldKp = await makeTestKeypair();
+    const newKp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, oldKp) });
+    const { by_old_key } = await buildRotateRequest(oldKp, newKp);
+    const res = await onRequestPost({ request: req({ by_old_key }), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("rotates on valid co-signed request (200) and appends to rotations[]", async () => {
+    const oldKp = await makeTestKeypair();
+    const newKp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, oldKp) });
+    const body = await buildRotateRequest(oldKp, newKp);
+    const res = await onRequestPost({ request: req(body), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(200);
+    const updated = await res.json();
+    const newPubB64 = btoa(String.fromCharCode(...newKp.mlDsa.publicKey));
+    expect(updated.pq_signing_pub).toBe(newPubB64);
+    expect(updated.pq_kid).toBe("testkid-new");
+    expect(Array.isArray(updated.rotations)).toBe(true);
+    expect(updated.rotations).toHaveLength(1);
+    expect(updated.rotations[0].new_pq_kid).toBe("testkid-new");
+    expect(updated.updated_at).toBeTypeOf("string");
+  });
+
+  it("appends (not overwrites) rotations[] across multiple rotations", async () => {
+    const k0 = await makeTestKeypair();
+    const k1 = await makeTestKeypair();
+    const k2 = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, k0) });
+    await onRequestPost({ request: req(await buildRotateRequest(k0, k1)), env, params: { rrn: RRN } } as any);
+    // After rotate 1, record's pq_signing_pub is now k1's pub. Next rotate's buildRotateRequest
+    // signs by_old_key with k1 (the new current) and by_new_key with k2.
+    await onRequestPost({ request: req(await buildRotateRequest(k1, k2)), env, params: { rrn: RRN } } as any);
+    const final = JSON.parse(env.__store[`robot:${RRN}`]);
+    expect(final.rotations).toHaveLength(2);
+    expect(final.pq_signing_pub).toBe(btoa(String.fromCharCode(...k2.mlDsa.publicKey)));
+  });
+});

--- a/functions/v2/robots/[rrn]/rotate-key.test.ts
+++ b/functions/v2/robots/[rrn]/rotate-key.test.ts
@@ -104,7 +104,7 @@ describe("POST /v2/robots/[rrn]/rotate-key", () => {
     expect(res.status).toBe(401);
   });
 
-  it("401 when by_new_key is signed by something other than the declared new key", async () => {
+  it("400 when by_new_key.pq_signing_pub does not match declared new_pq_signing_pub", async () => {
     const oldKp = await makeTestKeypair();
     const newKp = await makeTestKeypair();
     const otherKp = await makeTestKeypair();
@@ -121,6 +121,34 @@ describe("POST /v2/robots/[rrn]/rotate-key", () => {
       new_pq_signing_pub: btoa(String.fromCharCode(...newKp.mlDsa.publicKey)),
       new_pq_kid: "testkid-new",
     }, otherKp);
+    const res = await onRequestPost({ request: req({ by_old_key, by_new_key }), env, params: { rrn: RRN } } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("401 when by_new_key has a forged signature that doesn't verify under declared pq_signing_pub", async () => {
+    const oldKp = await makeTestKeypair();
+    const newKp = await makeTestKeypair();
+    const otherKp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: makeRobotRecord(RRN, oldKp) });
+
+    const canonical = {
+      rrn: RRN, action: "rotate" as const,
+      new_pq_signing_pub: btoa(String.fromCharCode(...newKp.mlDsa.publicKey)),
+      new_pq_kid: "testkid-new",
+    };
+
+    const by_old_key = await signComplianceBody(canonical, oldKp);
+
+    // Two separately-signed envelopes over the SAME canonical doc.
+    const envA_signedByNewKp = await signComplianceBody(canonical, newKp);
+    const envB_signedByOtherKp = await signComplianceBody(canonical, otherKp);
+
+    // Forgery: keep envelope A's structure (declares newKp's pub as pq_signing_pub)
+    // but swap in envelope B's sig (which was signed over envelope B's canonical
+    // where pq_signing_pub was otherKp's pub — different bytes). Consistency check
+    // at I1's site passes; verifyBody under newKp's public key fails.
+    const by_new_key = { ...envA_signedByNewKp, sig: envB_signedByOtherKp.sig };
+
     const res = await onRequestPost({ request: req({ by_old_key, by_new_key }), env, params: { rrn: RRN } } as any);
     expect(res.status).toBe(401);
   });

--- a/functions/v2/robots/[rrn]/rotate-key.ts
+++ b/functions/v2/robots/[rrn]/rotate-key.ts
@@ -1,0 +1,100 @@
+import { isValidId } from "../../_lib/id.js";
+import { verifyBody } from "rcan-ts";
+import { isRevoked } from "../../_lib/revocation.js";
+
+export interface Env { RRF_KV: KVNamespace }
+
+/**
+ * POST /v2/robots/:rrn/rotate-key
+ *
+ * Co-signed rotation: the request body carries TWO independently-signed envelopes
+ * (`by_old_key`, `by_new_key`), each a self-contained verifyBody-compatible doc
+ * over the canonical `{rrn, action:"rotate", new_pq_signing_pub, new_pq_kid}`.
+ *
+ * Known limitation: Cloudflare Workers KV has no CAS primitive in this project's
+ * setup. Two concurrent rotate requests can both verify and both write — last-write
+ * wins. Rotations are rare, user-initiated events; the `rotations[]` audit log will
+ * reflect a collision post-facto. Optimistic versioning is deferred.
+ */
+
+function err(msg: string, status: number): Response {
+  return new Response(JSON.stringify({ error: msg }), {
+    status, headers: { "Content-Type": "application/json" },
+  });
+}
+
+function agrees(a: any, b: any, keys: string[]): boolean {
+  for (const k of keys) if (a?.[k] !== b?.[k]) return false;
+  return true;
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env, params }) => {
+  const rrn = params.rrn as string;
+  if (!isValidId(rrn, "RRN")) return err("Invalid RRN format", 400);
+
+  let body: any;
+  try { body = await request.json(); }
+  catch { return err("Invalid JSON body", 400); }
+
+  const byOld = body?.by_old_key;
+  const byNew = body?.by_new_key;
+  if (!byOld || typeof byOld !== "object" || !byNew || typeof byNew !== "object") {
+    return err("Missing by_old_key or by_new_key envelopes", 400);
+  }
+
+  const stored = await env.RRF_KV.get(`robot:${rrn}`, "text");
+  if (!stored) return err("Not found", 404);
+
+  if (await isRevoked(env, rrn)) return err("Record is revoked", 403);
+
+  const record = JSON.parse(stored);
+  const currentPubB64 = record.pq_signing_pub;
+  if (typeof currentPubB64 !== "string") return err("Record has no registered key", 400);
+
+  // Agreement: both envelopes declare the same canonical rotation fields,
+  // and that canonical binds to the URL RRN + action "rotate".
+  if (!agrees(byOld, byNew, ["rrn", "action", "new_pq_signing_pub", "new_pq_kid"])) {
+    return err("Envelopes disagree on canonical rotation fields", 400);
+  }
+  if (byOld.rrn !== rrn) return err("Envelope rrn does not match URL", 400);
+  if (byOld.action !== "rotate") return err("Envelope action must be rotate", 400);
+
+  const newPubB64 = byOld.new_pq_signing_pub;
+  const newKid = byOld.new_pq_kid;
+  if (typeof newPubB64 !== "string" || typeof newKid !== "string") {
+    return err("new_pq_signing_pub and new_pq_kid must be strings", 400);
+  }
+  if (newPubB64 === currentPubB64) return err("Rotation requires a different key", 400);
+
+  // Consistency: the new envelope must be signed BY the declared new key
+  // (i.e. its inner pq_signing_pub field equals new_pq_signing_pub).
+  if (byNew.pq_signing_pub !== newPubB64) {
+    return err("by_new_key not signed by the declared new key", 401);
+  }
+
+  // Verify both envelopes.
+  let oldOk = false, newOk = false;
+  try {
+    const oldPub = Uint8Array.from(atob(currentPubB64), c => c.charCodeAt(0));
+    oldOk = await verifyBody(byOld, oldPub);
+  } catch { /* oldOk stays false */ }
+  if (!oldOk) return err("by_old_key signature verification failed", 401);
+
+  try {
+    const newPub = Uint8Array.from(atob(newPubB64), c => c.charCodeAt(0));
+    newOk = await verifyBody(byNew, newPub);
+  } catch { /* newOk stays false */ }
+  if (!newOk) return err("by_new_key signature verification failed", 401);
+
+  // Apply rotation.
+  const now = new Date().toISOString();
+  record.rotations = Array.isArray(record.rotations) ? record.rotations : [];
+  record.rotations.push({ rotated_at: now, old_pq_kid: record.pq_kid, new_pq_kid: newKid });
+  record.pq_signing_pub = newPubB64;
+  record.pq_kid = newKid;
+  record.updated_at = now;
+  await env.RRF_KV.put(`robot:${rrn}`, JSON.stringify(record));
+  return new Response(JSON.stringify(record), {
+    status: 200, headers: { "Content-Type": "application/json" },
+  });
+};

--- a/functions/v2/robots/[rrn]/rotate-key.ts
+++ b/functions/v2/robots/[rrn]/rotate-key.ts
@@ -1,6 +1,7 @@
 import { isValidId } from "../../_lib/id.js";
 import { verifyBody } from "rcan-ts";
 import { isRevoked } from "../../_lib/revocation.js";
+import { redactRobotRecord } from "../../_lib/redact.js";
 
 export interface Env { RRF_KV: KVNamespace }
 
@@ -94,7 +95,7 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env, params }
   record.pq_kid = newKid;
   record.updated_at = now;
   await env.RRF_KV.put(`robot:${rrn}`, JSON.stringify(record));
-  return new Response(JSON.stringify(record), {
+  return new Response(JSON.stringify(redactRobotRecord(record)), {
     status: 200, headers: { "Content-Type": "application/json" },
   });
 };

--- a/functions/v2/robots/[rrn]/rotate-key.ts
+++ b/functions/v2/robots/[rrn]/rotate-key.ts
@@ -69,7 +69,7 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env, params }
   // Consistency: the new envelope must be signed BY the declared new key
   // (i.e. its inner pq_signing_pub field equals new_pq_signing_pub).
   if (byNew.pq_signing_pub !== newPubB64) {
-    return err("by_new_key not signed by the declared new key", 401);
+    return err("by_new_key.pq_signing_pub must match declared new_pq_signing_pub", 400);
   }
 
   // Verify both envelopes.

--- a/functions/v2/robots/[rrn]/verify-tier.test.ts
+++ b/functions/v2/robots/[rrn]/verify-tier.test.ts
@@ -1,0 +1,214 @@
+// functions/v2/robots/[rrn]/verify-tier.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { onRequestPost } from "./verify-tier.js";
+import { makeTestKeypair, makeRobotRecord, signComplianceBody } from "../../_lib/test-helpers.js";
+
+const RRN = "RRN-000000000042";
+const DOMAIN = "robotis.com";
+const RURI = "https://robotis.com";
+
+function makeEnv(init: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...init };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+      delete: vi.fn(async (k: string) => { delete store[k]; }),
+      list: vi.fn(),
+    } as unknown as KVNamespace,
+    __store: store,
+  };
+}
+
+function req(body: unknown): Request {
+  return new Request(`https://x/v2/robots/${RRN}/verify-tier`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// Option C: stamp pq_kid to match signBody's output for this keypair.
+// makeRobotRecord hardcodes pq_kid:"testkid1" which diverges from what
+// kidFromPub(kp.mlDsa.publicKey) produces. We fix that by signing a probe
+// body and reading the stamped pq_kid back — consistent with signBody's own
+// algorithm without coupling to the internal SHA-256 truncation.
+async function makeRecordWithModel(kp: Awaited<ReturnType<typeof makeTestKeypair>>, model: string): Promise<string> {
+  const rec = JSON.parse(makeRobotRecord(RRN, kp));
+  rec.model = model;
+  const sample = await signComplianceBody({ probe: true }, kp);
+  rec.pq_kid = sample.pq_kid as string;
+  return JSON.stringify(rec);
+}
+
+describe("POST /v2/robots/[rrn]/verify-tier", () => {
+  it("rejects target_tier=community (maintainer-curated, not promotable via API)", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger") });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "community", binding: { type: "dns-txt", value: DOMAIN } },
+      kp,
+    );
+    const verifiers = { dns: vi.fn(), attestation: vi.fn() };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when target_tier is unknown", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger") });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "wizard_tier", binding: { type: "dns-txt", value: DOMAIN } },
+      kp,
+    );
+    const verifiers = { dns: vi.fn(), attestation: vi.fn() };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("promotes to manufacturer_claimed when DNS verifies", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger") });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "manufacturer_claimed", binding: { type: "dns-txt", value: DOMAIN } },
+      kp,
+    );
+    const verifiers = {
+      dns: vi.fn(async () => ({ ok: true, evidence: `rrn=${RRN};model=turtlebot3_burger` })),
+      attestation: vi.fn(),
+    };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(200);
+    const updated = JSON.parse(env.__store[`robot:${RRN}`]);
+    expect(updated.verification_status).toBe("manufacturer_claimed");
+    expect(updated.identity_binding).toMatchObject({ type: "dns-txt", value: DOMAIN });
+    expect(typeof updated.identity_binding.verified_at).toBe("string");
+    expect(verifiers.dns).toHaveBeenCalledWith(DOMAIN, RRN, "turtlebot3_burger");
+    expect(verifiers.attestation).not.toHaveBeenCalled();
+  });
+
+  it("400 when DNS verifier fails", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger") });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "manufacturer_claimed", binding: { type: "dns-txt", value: DOMAIN } },
+      kp,
+    );
+    const verifiers = {
+      dns: vi.fn(async () => ({ ok: false, error: "TXT record not found" })),
+      attestation: vi.fn(),
+    };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("promotes to manufacturer_verified when DNS + attestation both verify", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger") });
+    // Build the attestation via signComplianceBody so .pq_kid matches record.pq_kid.
+    const attestation = await signComplianceBody(
+      { rrn: RRN, manufacturer: "ROBOTIS", model: "turtlebot3_burger", timestamp_iso: "2026-04-24T00:00:00Z" },
+      kp,
+    );
+    const signed = await signComplianceBody(
+      {
+        rrn: RRN, action: "verify-tier", target_tier: "manufacturer_verified",
+        binding: { type: "dns-txt", value: DOMAIN },
+        ruri: RURI, attestation,
+      },
+      kp,
+    );
+    const verifiers = {
+      dns: vi.fn(async () => ({ ok: true, evidence: `rrn=${RRN};model=turtlebot3_burger` })),
+      attestation: vi.fn(async () => ({
+        ok: true,
+        evidence: { attestation_digest: "deadbeef", ruri_matched: `${RURI}/.well-known/rcan-manifest.json` },
+      })),
+    };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(200);
+    const updated = JSON.parse(env.__store[`robot:${RRN}`]);
+    expect(updated.verification_status).toBe("manufacturer_verified");
+    expect(verifiers.dns).toHaveBeenCalled();
+    expect(verifiers.attestation).toHaveBeenCalled();
+  });
+
+  it("400 on downgrade attempt (current=manufacturer_verified, target=manufacturer_claimed)", async () => {
+    const kp = await makeTestKeypair();
+    const record = JSON.parse(await makeRecordWithModel(kp, "turtlebot3_burger"));
+    record.verification_status = "manufacturer_verified";
+    const env = makeEnv({ [`robot:${RRN}`]: JSON.stringify(record) });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "manufacturer_claimed", binding: { type: "dns-txt", value: DOMAIN } },
+      kp,
+    );
+    const verifiers = { dns: vi.fn(), attestation: vi.fn() };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("403 when record is revoked", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({
+      [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger"),
+      [`revocation:${RRN}`]: JSON.stringify({ revoked_at: "2026-04-24T00:00:00Z", reason: "test" }),
+    });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "manufacturer_claimed", binding: { type: "dns-txt", value: DOMAIN } },
+      kp,
+    );
+    const verifiers = { dns: vi.fn(), attestation: vi.fn() };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(403);
+  });
+
+  it("401 when outer sig does not verify under record's key", async () => {
+    const kp = await makeTestKeypair();
+    const attackerKp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger") });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "manufacturer_claimed", binding: { type: "dns-txt", value: DOMAIN } },
+      attackerKp,
+    );
+    const verifiers = { dns: vi.fn(), attestation: vi.fn() };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(401);
+  });
+
+  it("400 when manufacturer_verified request is missing ruri or attestation", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger") });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "manufacturer_verified", binding: { type: "dns-txt", value: DOMAIN } },
+      kp,
+    );
+    const verifiers = { dns: vi.fn(), attestation: vi.fn() };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when manufacturer_verified attestation.pq_kid does not match record.pq_kid", async () => {
+    const kp = await makeTestKeypair();
+    const otherKp = await makeTestKeypair();
+    const env = makeEnv({ [`robot:${RRN}`]: await makeRecordWithModel(kp, "turtlebot3_burger") });
+    // Attestation signed by otherKp, so its pq_kid will differ from record's pq_kid.
+    const attestation = await signComplianceBody(
+      { rrn: RRN, manufacturer: "ROBOTIS", model: "turtlebot3_burger", timestamp_iso: "2026-04-24T00:00:00Z" },
+      otherKp,
+    );
+    const signed = await signComplianceBody(
+      {
+        rrn: RRN, action: "verify-tier", target_tier: "manufacturer_verified",
+        binding: { type: "dns-txt", value: DOMAIN },
+        ruri: RURI, attestation,
+      },
+      kp,
+    );
+    const verifiers = {
+      dns: vi.fn(async () => ({ ok: true, evidence: `rrn=${RRN};model=turtlebot3_burger` })),
+      attestation: vi.fn(async () => ({ ok: true, evidence: { attestation_digest: "x", ruri_matched: RURI } })),
+    };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/functions/v2/robots/[rrn]/verify-tier.test.ts
+++ b/functions/v2/robots/[rrn]/verify-tier.test.ts
@@ -79,6 +79,9 @@ describe("POST /v2/robots/[rrn]/verify-tier", () => {
     };
     const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
     expect(res.status).toBe(200);
+    const responseBody = await res.json();
+    expect(responseBody.api_key).toBeUndefined();
+    expect(responseBody.verification_status).toBe("manufacturer_claimed");
     const updated = JSON.parse(env.__store[`robot:${RRN}`]);
     expect(updated.verification_status).toBe("manufacturer_claimed");
     expect(updated.identity_binding).toMatchObject({ type: "dns-txt", value: DOMAIN });
@@ -131,6 +134,9 @@ describe("POST /v2/robots/[rrn]/verify-tier", () => {
     expect(updated.verification_status).toBe("manufacturer_verified");
     expect(verifiers.dns).toHaveBeenCalled();
     expect(verifiers.attestation).toHaveBeenCalled();
+    expect(updated.identity_binding.verifier_evidence).toContain(`attestation=deadbeef`);
+    expect(updated.identity_binding.verifier_evidence).toContain(`dns=`);
+    expect(updated.identity_binding.verifier_evidence).toContain(`ruri=${RURI}`);
   });
 
   it("400 on downgrade attempt (current=manufacturer_verified, target=manufacturer_claimed)", async () => {
@@ -185,6 +191,20 @@ describe("POST /v2/robots/[rrn]/verify-tier", () => {
     const verifiers = { dns: vi.fn(), attestation: vi.fn() };
     const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
     expect(res.status).toBe(400);
+  });
+
+  it("409 when record has an unrecognized verification_status (legacy tier)", async () => {
+    const kp = await makeTestKeypair();
+    const record = JSON.parse(await makeRecordWithModel(kp, "turtlebot3_burger"));
+    record.verification_status = "certified";  // legacy tier from older enum
+    const env = makeEnv({ [`robot:${RRN}`]: JSON.stringify(record) });
+    const signed = await signComplianceBody(
+      { rrn: RRN, action: "verify-tier", target_tier: "manufacturer_claimed", binding: { type: "dns-txt", value: DOMAIN } },
+      kp,
+    );
+    const verifiers = { dns: vi.fn(), attestation: vi.fn() };
+    const res = await onRequestPost({ request: req(signed), env, params: { rrn: RRN }, verifiers } as any);
+    expect(res.status).toBe(409);
   });
 
   it("400 when manufacturer_verified attestation.pq_kid does not match record.pq_kid", async () => {

--- a/functions/v2/robots/[rrn]/verify-tier.ts
+++ b/functions/v2/robots/[rrn]/verify-tier.ts
@@ -1,0 +1,127 @@
+/**
+ * POST /v2/robots/:rrn/verify-tier
+ *
+ * Promotes a robot's verification_status to manufacturer_claimed or
+ * manufacturer_verified. community tier is NOT promotable via this endpoint —
+ * it is maintainer-curated via PR against src/content/robots/<slug>.json, per
+ * rcan-spec/docs/verification/manufacturer-verification.md.
+ *
+ * Request is signed with the robot's current pq_signing_pub. The outer sig is
+ * verified, tier progression enforced (no downgrades), then the appropriate
+ * verifier(s) run:
+ *   - manufacturer_claimed: DNS TXT verifier only.
+ *   - manufacturer_verified: DNS TXT + signed attestation + RURI manifest.
+ *
+ * The DNS and attestation verifiers are injectable via ctx.verifiers for tests.
+ */
+
+import { isValidId } from "../../_lib/id.js";
+import { verifyBody } from "rcan-ts";
+import { isRevoked } from "../../_lib/revocation.js";
+import { verifyDnsTxt } from "../../_lib/dns-verify.js";
+import { verifyAttestation } from "../../_lib/attestation-verify.js";
+
+export interface Env { RRF_KV: KVNamespace }
+
+type DnsVerifierFn = typeof verifyDnsTxt;
+type AttestationVerifierFn = typeof verifyAttestation;
+interface Verifiers { dns: DnsVerifierFn; attestation: AttestationVerifierFn }
+
+const TIER_ORDER = ["unverified", "community", "manufacturer_claimed", "manufacturer_verified"] as const;
+type Tier = typeof TIER_ORDER[number];
+
+function err(msg: string, status: number): Response {
+  return new Response(JSON.stringify({ error: msg }), {
+    status, headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestPost: PagesFunction<Env> = async (ctx) => {
+  const { request, env, params } = ctx;
+  const verifiers: Verifiers = (ctx as any).verifiers ?? { dns: verifyDnsTxt, attestation: verifyAttestation };
+  const rrn = params.rrn as string;
+
+  if (!isValidId(rrn, "RRN")) return err("Invalid RRN format", 400);
+
+  let body: any;
+  try { body = await request.json(); }
+  catch { return err("Invalid JSON body", 400); }
+
+  if (body?.action !== "verify-tier" || body?.rrn !== rrn) {
+    return err("Body must bind rrn and action:verify-tier", 400);
+  }
+
+  const targetTier = body?.target_tier;
+  if (targetTier === "community") {
+    return err("community tier is maintainer-curated (not promotable via API)", 400);
+  }
+  if (targetTier !== "manufacturer_claimed" && targetTier !== "manufacturer_verified") {
+    return err("target_tier must be manufacturer_claimed or manufacturer_verified", 400);
+  }
+
+  const binding = body?.binding;
+  if (!binding || binding.type !== "dns-txt" || typeof binding.value !== "string") {
+    return err("binding must be {type:'dns-txt', value:<domain>}", 400);
+  }
+
+  if (targetTier === "manufacturer_verified") {
+    if (typeof body?.ruri !== "string" || !body?.attestation || typeof body.attestation !== "object") {
+      return err("manufacturer_verified requires ruri + attestation", 400);
+    }
+  }
+
+  const stored = await env.RRF_KV.get(`robot:${rrn}`, "text");
+  if (!stored) return err("Not found", 404);
+
+  if (await isRevoked(env, rrn)) return err("Record is revoked", 403);
+
+  const record = JSON.parse(stored);
+  const pqPubB64 = record.pq_signing_pub;
+  if (typeof pqPubB64 !== "string") return err("Record has no registered key", 400);
+
+  let sigOk = false;
+  try {
+    const pub = Uint8Array.from(atob(pqPubB64), (c) => c.charCodeAt(0));
+    sigOk = await verifyBody(body, pub);
+  } catch { /* sigOk stays false */ }
+  if (!sigOk) return err("Signature verification failed", 401);
+
+  const currentTier = (record.verification_status ?? "unverified") as Tier;
+  const currentIdx = TIER_ORDER.indexOf(currentTier);
+  const targetIdx = TIER_ORDER.indexOf(targetTier);
+  if (targetIdx <= currentIdx) return err("Cannot downgrade or stay at current tier", 400);
+
+  const dns = await verifiers.dns(binding.value, rrn, record.model);
+  if (!dns.ok) return err(`DNS verification failed: ${dns.error}`, 400);
+
+  let ruriEvidence: string | undefined;
+  if (targetTier === "manufacturer_verified") {
+    // Bind the attestation to the registered key.
+    if (body.attestation.pq_kid !== record.pq_kid) {
+      return err("attestation.pq_kid does not match record.pq_kid", 400);
+    }
+    const att = await verifiers.attestation({
+      attestation: body.attestation,
+      ruri: body.ruri,
+      pqPubB64,
+      expectedRrn: rrn,
+      expectedModel: record.model,
+    });
+    if (!att.ok) return err(`Attestation verification failed: ${att.error}`, 400);
+    ruriEvidence = att.evidence.ruri_matched;
+  }
+
+  const now = new Date().toISOString();
+  record.verification_status = targetTier;
+  record.identity_binding = {
+    type: "dns-txt",
+    value: binding.value,
+    verified_at: now,
+    verifier_evidence: ruriEvidence ? `${dns.evidence}; ${ruriEvidence}` : dns.evidence,
+  };
+  record.updated_at = now;
+  await env.RRF_KV.put(`robot:${rrn}`, JSON.stringify(record));
+  return new Response(JSON.stringify(record), {
+    status: 200, headers: { "Content-Type": "application/json" },
+  });
+};

--- a/functions/v2/robots/[rrn]/verify-tier.ts
+++ b/functions/v2/robots/[rrn]/verify-tier.ts
@@ -20,6 +20,7 @@ import { verifyBody } from "rcan-ts";
 import { isRevoked } from "../../_lib/revocation.js";
 import { verifyDnsTxt } from "../../_lib/dns-verify.js";
 import { verifyAttestation } from "../../_lib/attestation-verify.js";
+import { redactRobotRecord } from "../../_lib/redact.js";
 
 export interface Env { RRF_KV: KVNamespace }
 
@@ -27,8 +28,13 @@ type DnsVerifierFn = typeof verifyDnsTxt;
 type AttestationVerifierFn = typeof verifyAttestation;
 interface Verifiers { dns: DnsVerifierFn; attestation: AttestationVerifierFn }
 
-const TIER_ORDER = ["unverified", "community", "manufacturer_claimed", "manufacturer_verified"] as const;
-type Tier = typeof TIER_ORDER[number];
+const TIER_RANK: Record<string, number> = {
+  unverified: 0,
+  community: 1,
+  manufacturer_claimed: 2,
+  manufacturer_verified: 3,
+};
+type Tier = keyof typeof TIER_RANK;
 
 function err(msg: string, status: number): Response {
   return new Response(JSON.stringify({ error: msg }), {
@@ -86,15 +92,18 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
   } catch { /* sigOk stays false */ }
   if (!sigOk) return err("Signature verification failed", 401);
 
-  const currentTier = (record.verification_status ?? "unverified") as Tier;
-  const currentIdx = TIER_ORDER.indexOf(currentTier);
-  const targetIdx = TIER_ORDER.indexOf(targetTier);
-  if (targetIdx <= currentIdx) return err("Cannot downgrade or stay at current tier", 400);
+  const currentTier = record.verification_status ?? "unverified";
+  const currentRank = TIER_RANK[currentTier];
+  if (currentRank === undefined) {
+    return err(`Record has unrecognized verification_status: ${currentTier}`, 409);
+  }
+  const targetRank = TIER_RANK[targetTier];  // already validated to be a known tier string above
+  if (targetRank <= currentRank) return err("Cannot downgrade or stay at current tier", 400);
 
   const dns = await verifiers.dns(binding.value, rrn, record.model);
   if (!dns.ok) return err(`DNS verification failed: ${dns.error}`, 400);
 
-  let ruriEvidence: string | undefined;
+  let attestationEvidence: { attestation_digest: string; ruri_matched: string } | undefined;
   if (targetTier === "manufacturer_verified") {
     // Bind the attestation to the registered key.
     if (body.attestation.pq_kid !== record.pq_kid) {
@@ -108,7 +117,7 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
       expectedModel: record.model,
     });
     if (!att.ok) return err(`Attestation verification failed: ${att.error}`, 400);
-    ruriEvidence = att.evidence.ruri_matched;
+    attestationEvidence = att.evidence;
   }
 
   const now = new Date().toISOString();
@@ -117,11 +126,13 @@ export const onRequestPost: PagesFunction<Env> = async (ctx) => {
     type: "dns-txt",
     value: binding.value,
     verified_at: now,
-    verifier_evidence: ruriEvidence ? `${dns.evidence}; ${ruriEvidence}` : dns.evidence,
+    verifier_evidence: attestationEvidence
+      ? `dns=${dns.evidence}; ruri=${attestationEvidence.ruri_matched}; attestation=${attestationEvidence.attestation_digest}`
+      : `dns=${dns.evidence}`,
   };
   record.updated_at = now;
   await env.RRF_KV.put(`robot:${rrn}`, JSON.stringify(record));
-  return new Response(JSON.stringify(record), {
+  return new Response(JSON.stringify(redactRobotRecord(record)), {
     status: 200, headers: { "Content-Type": "application/json" },
   });
 };

--- a/functions/v2/robots/register.test.ts
+++ b/functions/v2/robots/register.test.ts
@@ -81,4 +81,16 @@ describe("POST /v2/robots/register — signing enforcement (RCAN 3.0 §2.2)", ()
     expect(json.rrn).toMatch(/^RRN-\d{12}$/);
     expect(json.record_url).toContain("robotregistryfoundation.org");
   });
+
+  it("new records default verification_status to 'unverified'", async () => {
+    const env = makeEnv();
+    const res = await onRequestPost({ request: makePost(fx.http_body), env } as any);
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    const rrn = json.rrn;
+
+    // Read the stored record from KV
+    const stored = JSON.parse(env.__store[`robot:${rrn}`]);
+    expect(stored.verification_status).toBe("unverified");
+  });
 });

--- a/functions/v2/robots/register.ts
+++ b/functions/v2/robots/register.ts
@@ -70,6 +70,7 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     rcn_ids,
     rmn,
     rhn_ids,
+    verification_status: "unverified",
     loa_enforcement: body.loa_enforcement !== false,  // default true
     registered_at:   new Date().toISOString(),
   };


### PR DESCRIPTION
## Summary

Closes the three auth gaps surfaced by the 2026-04-24 RRF write-auth audit, landing on RRF in one branch. CLI-side work (Plan 1 Tasks 10-12) ships separately.

**Capabilities added:**
- **Revocation** — `POST /v2/robots/:rrn/revoke-key` (signature-authenticated, no Bearer). All §22-26 compliance intakes (FRIA, IFU, safety-benchmark, incident-report, EU-register) refuse revoked entities. PATCH refuses revoked records. GET surfaces a `revoked` / `revoked_at` pair.
- **Rotation** — `POST /v2/robots/:rrn/rotate-key` with co-signed envelopes (`by_old_key` + `by_new_key`, each a full `signBody` output). Appends to `rotations[]` audit array.
- **Tier-gated identity binding** — `POST /v2/robots/:rrn/verify-tier` promotes to `manufacturer_claimed` (DNS TXT verified) or `manufacturer_verified` (DNS TXT + signed attestation + live RURI). `community` tier stays maintainer-curated (PR path). `unverified` remains the zero-friction default, set automatically on register.

**Security fix landed in the same branch:** `GET /v2/robots/:rrn` is public and was echoing the stored record including `api_key`, publicly exposing robot bearer credentials. Added `_lib/redact.ts` and applied to all 4 response sites (GET, PATCH, rotate-key, verify-tier). KV-stored records unchanged; only response bodies are redacted.

## Design decisions locked in the plan doc

- Rotation envelope: co-signed two-envelope design (not single-payload-two-sigs — that conflicted with rcan-ts's `verifyBody` canonicalization). Both envelopes bind the same `{rrn, action:"rotate", new_pq_signing_pub, new_pq_kid}` canonical.
- `community` tier dropped from the API; lives only as a maintainer-curated PR flow per `rcan-spec/docs/verification/manufacturer-verification.md`.
- DNS TXT verification is one-shot at promotion (stored as `verified_at` in `identity_binding`); periodic re-check is a future task.
- Attestation verifier caps RURI response at 64 KiB (DoS defense, server-side verifier).

## Known limitations

- **Rotate-key KV race** — Cloudflare Workers KV has no CAS primitive in this setup. Two concurrent rotate requests can both verify and both write (last-write-wins). `rotations[]` audit log will reflect the collision post-facto. Optimistic versioning is a follow-up. Documented in `rotate-key.ts` and the plan doc.
- **No replay protection on revoke-key** — a captured signed revoke payload is replayable. Damage caps at one unwanted revocation (re-revoke returns 409). Accepted for v1; a `not_before`/`nonce` field is a future design decision.

## Test coverage

- **96 → 161 tests** (+65 across 7 new files). Full suite green.
- Every new endpoint has RED-verified TDD tests for happy path + each 4xx branch.
- Three forgery-path tests exercise the real crypto verification (not the cheap consistency checks that precede it).
- Redaction regression tests assert `api_key` is not in any response body.

## Test plan
- [ ] `npm test` passes 161/161 in this branch
- [ ] Cloudflare preview deploys clean (`wrangler pages` build)
- [ ] Manual smoke: register a throwaway RRN on staging, revoke it, confirm compliance POST returns 403
- [ ] Manual smoke: DNS-TXT promotion against a real `_rcan-verify.<domain>` record (requires a test domain)
- [ ] Manual smoke: confirm `curl /v2/robots/:rrn` response body does NOT include `api_key`

## Commits (15)

```
cd166b1 feat(rrf): default verification_status to unverified on register
8dbc2df fix(rrf): strip api_key from response bodies; tier-rank guard; include attestation digest in evidence
a082c13 feat(rrf): add POST /v2/robots/:rrn/verify-tier (manufacturer_claimed + manufacturer_verified)
a593069 fix(rrf): attestation-verify — include pq_kid in digest; cap RURI body at 64KiB
0013e69 feat(rrf): add signed-attestation + RURI verifier
e1d22b1 fix(rrf): dns-verify — multi-string TXT support; expose Status; test Accept header + fallback
779219c feat(rrf): add DNS TXT verifier for manufacturer_claimed tier
b6404e7 fix(rrf): pin PATCH revocation ordering with test; parallelize GET KV reads
cb7c5c2 feat(rrf): PATCH refuses revoked records; GET surfaces revoked flag
8810930 fix(rrf): rotate-key — consistency check is 400 not 401; add true verifyBody-forgery test
26eee7d feat(rrf): add POST /v2/robots/:rrn/rotate-key (co-signed envelopes)
f498f8d fix(rrf): revoke-key — reject non-string reason; add action-mismatch test
5a26dd6 feat(rrf): add POST /v2/robots/:rrn/revoke-key
fd661fb feat(rrf): refuse compliance submissions for revoked entities
aa7b2f0 feat(rrf): add revocation KV helper
```

## Plan source

`robot-md/docs/superpowers/plans/2026-04-24-rrf-tier-gated-write-auth.md` — CLI-side tasks (10-12) and docs update (Task 14) remain; opening separate PRs when those branches land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)