### PR TITLE
spike: rrf-mcp — half-day MCP server, all four Anthropic surfaces

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.wrangler/
+*.log

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,162 @@
+# @rrf/mcp — Robot Registry Foundation MCP server
+
+> **Status: spike (0.1.0-spike).** Read-only tools wrapping the public RRF
+> endpoints. Write tools (register, submit signed artifacts, submit Score
+> JSONs) are deferred until the apikey-bound trust surface is designed.
+
+Connect Claude — via any of the four Anthropic surfaces — directly to the
+Robot Registry Foundation: lookup robots by RRN, list the registry,
+fetch the spatial-eval spec metadata + RRF public key, poll counter-signed
+spatial-eval submissions, and fetch stored FRIA documents.
+
+## Tools
+
+| Tool | Endpoint | Auth |
+|---|---|---|
+| `rrf_lookup_robot(rrn)` | `GET /v2/robots/{rrn}` | public |
+| `rrf_list_registry(type?, limit?)` | `GET /v2/registry` | public |
+| `rrf_fetch_spatial_eval_spec(version)` | `GET /v1/spatial-eval/spec/{version}` | public |
+| `rrf_fetch_spatial_eval_run(submission_id)` | `GET /v1/spatial-eval/runs/{id}` | Bearer |
+| `rrf_fetch_fria(rrn)` | `GET /v2/robots/{rrn}/fria` | Bearer |
+
+For Bearer-gated tools, pass an apikey via `RRF_API_KEY` env var.
+
+## Quick start
+
+```sh
+git clone https://github.com/craigm26/RobotRegistryFoundation
+cd RobotRegistryFoundation/mcp
+npm install
+npm run build
+node dist/server.js   # speaks MCP over stdio
+```
+
+For local development against `wrangler pages dev`:
+
+```sh
+RRF_BASE=http://localhost:8788 node dist/server.js
+```
+
+## Connecting from each Anthropic surface
+
+### 1. Claude Desktop
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`
+(macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "rrf": {
+      "command": "node",
+      "args": ["/absolute/path/to/RobotRegistryFoundation/mcp/dist/server.js"],
+      "env": { "RRF_API_KEY": "your-bearer-here-if-needed" }
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The five `rrf_*` tools appear in the tools menu.
+
+### 2. Claude Code
+
+Use the `claude mcp add` CLI:
+
+```sh
+claude mcp add rrf -- node /absolute/path/to/RobotRegistryFoundation/mcp/dist/server.js
+```
+
+Or in `.claude/settings.json` per-project:
+
+```json
+{
+  "mcpServers": {
+    "rrf": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./mcp/dist/server.js"]
+    }
+  }
+}
+```
+
+### 3. claude.ai (web — Connectors)
+
+claude.ai supports MCP via the **Custom Connector** flow under Settings →
+Connectors. Custom connectors expect HTTP/SSE transports rather than
+stdio. Spike v0.1 ships stdio only — graduating to claude.ai requires
+adding the `StreamableHTTPServerTransport` from `@modelcontextprotocol/sdk`
+and exposing the server behind a public URL.
+
+This is a one-evening follow-up; the tool surface stays identical.
+
+### 4. Claude Agent SDK
+
+Python:
+
+```py
+from anthropic.beta.mcp import StdioMCPServer
+
+rrf = StdioMCPServer(
+    command="node",
+    args=["/abs/path/RobotRegistryFoundation/mcp/dist/server.js"],
+    env={"RRF_API_KEY": "..."},  # optional
+)
+# pass into your Agent's mcp_servers=[rrf]
+```
+
+TypeScript:
+
+```ts
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const transport = new StdioClientTransport({
+  command: "node",
+  args: ["/abs/path/RobotRegistryFoundation/mcp/dist/server.js"],
+});
+const client = new Client({ name: "agent", version: "1.0" }, { capabilities: {} });
+await client.connect(transport);
+const tools = await client.listTools();
+```
+
+## Manual smoke
+
+After `npm run build`, in another terminal:
+
+```sh
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | node dist/server.js
+```
+
+Should emit a JSON-RPC response listing the five tools. (For interactive
+exercise, use Claude Desktop with the config above and ask: *"What robots
+are in the RRF registry?"*)
+
+## Configuration
+
+| Env | Default | Purpose |
+|---|---|---|
+| `RRF_BASE` | `https://robotregistryfoundation.org` | Base URL — point at `localhost:8788` for `wrangler pages dev`. |
+| `RRF_API_KEY` | (unset) | Bearer apikey for `rrf_fetch_spatial_eval_run` and `rrf_fetch_fria`. Public tools work without it. |
+
+## Tests
+
+```sh
+npx vitest run --config vitest.config.ts
+```
+
+10 tests cover tool definitions, endpoint mapping, Bearer header
+propagation, and graceful error envelopes on 404.
+
+## Open questions for graduation
+
+- **Own repo or stay nested?** Currently lives in `mcp/` of the website
+  repo. Lower friction during the spike; gets noisy if it grows. Decision
+  point: when we add write tools (which need apikey-bound trust + a small
+  config UX), promote to `RobotRegistryFoundation/rrf-mcp`.
+- **Streamable HTTP transport** for claude.ai Custom Connector support.
+- **Caching** for `rrf_fetch_spatial_eval_spec` (pubkey changes only on
+  minor version bump — could cache aggressively).
+- **Write tools** with apikey-bound auth: register, submit-fria,
+  submit-ifu, submit-incident-report, submit-score, etc. Each is a
+  parallel of the public-side `robot-md` CLI command.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@rrf/mcp",
+  "version": "0.1.0-spike",
+  "description": "MCP server exposing the Robot Registry Foundation registry to Claude Desktop, Claude Code, claude.ai, and the Claude Agent SDK.",
+  "type": "module",
+  "private": true,
+  "bin": {
+    "rrf-mcp": "./dist/server.js"
+  },
+  "exports": {
+    ".": "./dist/server.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "dev": "tsx src/server.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.9"
+  }
+}

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -1,0 +1,97 @@
+/**
+ * Thin fetch client for the public RRF endpoints.
+ *
+ * One method per endpoint; no caching, no retries, no auth complexity
+ * for the spike. Bearer headers pass through verbatim when the caller
+ * provides them — write tools (which need apikey-bound auth) are out of
+ * scope here.
+ *
+ * Configurable via RRF_BASE env so a developer can point at
+ * http://localhost:8788 (wrangler pages dev) instead of production.
+ */
+
+const DEFAULT_BASE = "https://robotregistryfoundation.org";
+
+export interface RrfClientOptions {
+  base?: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class RrfHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly url: string,
+    public readonly body: unknown,
+  ) {
+    super(`RRF ${url} returned ${status}: ${JSON.stringify(body).slice(0, 200)}`);
+  }
+}
+
+export class RrfClient {
+  private readonly base: string;
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: RrfClientOptions = {}) {
+    this.base = (opts.base ?? process.env.RRF_BASE ?? DEFAULT_BASE).replace(/\/$/, "");
+    this.apiKey = opts.apiKey ?? process.env.RRF_API_KEY;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  private async get(path: string, opts: { bearer?: boolean } = {}): Promise<unknown> {
+    const url = `${this.base}${path}`;
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (opts.bearer) {
+      if (!this.apiKey) {
+        throw new Error(
+          `${path} is Bearer-gated; pass --api-key or set RRF_API_KEY env`,
+        );
+      }
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+    const res = await this.fetchImpl(url, { headers });
+    const text = await res.text();
+    let body: unknown;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      body = { _raw: text.slice(0, 500) };
+    }
+    if (!res.ok) throw new RrfHttpError(res.status, url, body);
+    return body;
+  }
+
+  /** Look up a single robot record by RRN. Public. */
+  async lookupRobot(rrn: string): Promise<unknown> {
+    return this.get(`/v2/robots/${encodeURIComponent(rrn)}`);
+  }
+
+  /** Unified listing of registry entries (robots/components/models/harnesses).
+   * Server-side filter by `type` and `limit`. Public. */
+  async listRegistry(type?: string, limit?: number): Promise<unknown> {
+    const params = new URLSearchParams();
+    if (type) params.set("type", type);
+    if (limit !== undefined) params.set("limit", String(limit));
+    const q = params.toString();
+    return this.get(`/v2/registry${q ? `?${q}` : ""}`);
+  }
+
+  /** Fetch the canonical spatial-eval spec metadata for a version. Public. */
+  async fetchSpatialEvalSpec(version: string): Promise<unknown> {
+    return this.get(`/v1/spatial-eval/spec/${encodeURIComponent(version)}`);
+  }
+
+  /** Poll a counter-signed (or pending/rejected) spatial-eval submission.
+   * Bearer-gated. */
+  async fetchSpatialEvalRun(submissionId: string): Promise<unknown> {
+    return this.get(`/v1/spatial-eval/runs/${encodeURIComponent(submissionId)}`, {
+      bearer: true,
+    });
+  }
+
+  /** Fetch a stored FRIA document for a robot. Bearer-gated. */
+  async fetchFria(rrn: string): Promise<unknown> {
+    return this.get(`/v2/robots/${encodeURIComponent(rrn)}/fria`, { bearer: true });
+  }
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * @rrf/mcp — MCP server for the Robot Registry Foundation.
+ *
+ * Spike scope: read-only tools wrapping the public RRF endpoints. stdio
+ * transport (the surface Claude Desktop, Claude Code, claude.ai
+ * connectors, and the Claude Agent SDK all consume natively).
+ *
+ * Configurable via env:
+ *   RRF_BASE     — base URL (default https://robotregistryfoundation.org)
+ *   RRF_API_KEY  — Bearer apikey for the two Bearer-gated tools
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { RrfClient } from "./client.js";
+import { TOOL_DEFS, callTool } from "./tools.js";
+
+export function buildServer(client: RrfClient = new RrfClient()): Server {
+  const server = new Server(
+    { name: "rrf-mcp", version: "0.1.0-spike" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: TOOL_DEFS,
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args } = req.params;
+    const result = await callTool(client, name, args ?? {});
+    return {
+      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+    };
+  });
+
+  return server;
+}
+
+async function main(): Promise<void> {
+  const server = buildServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  // Stay alive on stdio. Errors from Server propagate up.
+}
+
+// Run if invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error("rrf-mcp fatal:", err);
+    process.exit(1);
+  });
+}

--- a/mcp/src/tools.ts
+++ b/mcp/src/tools.ts
@@ -1,0 +1,122 @@
+/**
+ * MCP tool definitions wrapping RrfClient methods. One tool per endpoint.
+ *
+ * Tools are read-only in this spike. Write surfaces (register, submit
+ * artifacts, submit scores) need apikey-bound trust which is its own
+ * design surface and gets a follow-up.
+ */
+
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { RrfClient, RrfHttpError } from "./client.js";
+
+const RRN_RE = "^RRN-[0-9]{12}$";
+const SPEC_VERSION_RE = "^[0-9]+\\.[0-9]+\\.[0-9]+$";
+const SUBMISSION_ID_RE = "^sub_[A-Za-z0-9-]+$";
+
+export const TOOL_DEFS: Tool[] = [
+  {
+    name: "rrf_lookup_robot",
+    description:
+      "Look up a single robot's registry record by its RRN. Returns the registered RCAN identity, manufacturer, firmware version, registered_at, and verification tier.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        rrn: { type: "string", pattern: RRN_RE, description: "RRN-XXXXXXXXXXXX" },
+      },
+      required: ["rrn"],
+    },
+  },
+  {
+    name: "rrf_list_registry",
+    description:
+      "List entries from the unified registry (robots, components, models, harnesses) — sorted by registration date, newest first. Optional type filter and result limit.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        type: {
+          type: "string",
+          enum: ["robot", "component", "model", "harness"],
+          description: "Filter to one entity type. Omit for unified listing.",
+        },
+        limit: { type: "integer", minimum: 1, maximum: 500 },
+      },
+    },
+  },
+  {
+    name: "rrf_fetch_spatial_eval_spec",
+    description:
+      "Fetch the canonical spatial-eval spec metadata for a version, including the RRF ML-DSA public key used to verify counter-signatures.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        version: {
+          type: "string",
+          pattern: SPEC_VERSION_RE,
+          description: "Semantic version, e.g. 1.0.0",
+        },
+      },
+      required: ["version"],
+    },
+  },
+  {
+    name: "rrf_fetch_spatial_eval_run",
+    description:
+      "Poll a spatial-eval submission by its submission_id. Returns one of {pending, counter_signed, rejected}; counter_signed responses include the RRF-counter-signed Score JSON. Requires a Bearer apikey.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        submission_id: {
+          type: "string",
+          pattern: SUBMISSION_ID_RE,
+          description: "RRF-issued sub_<opaque> id from POST /v1/spatial-eval/runs",
+        },
+      },
+      required: ["submission_id"],
+    },
+  },
+  {
+    name: "rrf_fetch_fria",
+    description:
+      "Fetch a robot's stored Fundamental Rights Impact Assessment (RCAN §22). Requires a Bearer apikey.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        rrn: { type: "string", pattern: RRN_RE, description: "RRN-XXXXXXXXXXXX" },
+      },
+      required: ["rrn"],
+    },
+  },
+];
+
+type Args = Record<string, unknown>;
+
+export async function callTool(
+  client: RrfClient,
+  name: string,
+  args: Args,
+): Promise<unknown> {
+  try {
+    switch (name) {
+      case "rrf_lookup_robot":
+        return await client.lookupRobot(String(args.rrn));
+      case "rrf_list_registry":
+        return await client.listRegistry(
+          args.type ? String(args.type) : undefined,
+          typeof args.limit === "number" ? args.limit : undefined,
+        );
+      case "rrf_fetch_spatial_eval_spec":
+        return await client.fetchSpatialEvalSpec(String(args.version));
+      case "rrf_fetch_spatial_eval_run":
+        return await client.fetchSpatialEvalRun(String(args.submission_id));
+      case "rrf_fetch_fria":
+        return await client.fetchFria(String(args.rrn));
+      default:
+        throw new Error(`unknown tool: ${name}`);
+    }
+  } catch (e) {
+    if (e instanceof RrfHttpError) {
+      return { error: e.message, status: e.status, url: e.url, body: e.body };
+    }
+    return { error: (e as Error).message };
+  }
+}

--- a/mcp/test/tools.test.ts
+++ b/mcp/test/tools.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from "vitest";
+import { RrfClient, RrfHttpError } from "../src/client.js";
+import { TOOL_DEFS, callTool } from "../src/tools.js";
+
+function makeFakeFetch(
+  routes: Record<string, { status?: number; body: unknown }>,
+): typeof fetch {
+  return vi.fn(async (url: string | URL | Request) => {
+    const u = typeof url === "string" ? url : url.toString();
+    const path = new URL(u).pathname + (new URL(u).search || "");
+    const route = routes[path];
+    if (!route) {
+      return new Response(JSON.stringify({ error: "no fixture" }), { status: 404 });
+    }
+    return new Response(JSON.stringify(route.body), {
+      status: route.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+describe("TOOL_DEFS", () => {
+  it("exposes the five spike tools", () => {
+    const names = TOOL_DEFS.map((t) => t.name).sort();
+    expect(names).toEqual([
+      "rrf_fetch_fria",
+      "rrf_fetch_spatial_eval_run",
+      "rrf_fetch_spatial_eval_spec",
+      "rrf_list_registry",
+      "rrf_lookup_robot",
+    ]);
+  });
+
+  it("each tool has an inputSchema", () => {
+    for (const t of TOOL_DEFS) {
+      expect(t.inputSchema).toBeDefined();
+      expect((t.inputSchema as { type: string }).type).toBe("object");
+    }
+  });
+});
+
+describe("rrf_lookup_robot", () => {
+  it("hits /v2/robots/{rrn} and returns the body", async () => {
+    const client = new RrfClient({
+      base: "https://x",
+      fetchImpl: makeFakeFetch({
+        "/v2/robots/RRN-000000000001": {
+          body: { rrn: "RRN-000000000001", name: "bob" },
+        },
+      }),
+    });
+    const out = await callTool(client, "rrf_lookup_robot", { rrn: "RRN-000000000001" });
+    expect(out).toEqual({ rrn: "RRN-000000000001", name: "bob" });
+  });
+
+  it("returns an error envelope on 404 instead of throwing", async () => {
+    const client = new RrfClient({
+      base: "https://x",
+      fetchImpl: makeFakeFetch({
+        "/v2/robots/RRN-000000000099": {
+          status: 404,
+          body: { error: "Not registered" },
+        },
+      }),
+    });
+    const out = (await callTool(client, "rrf_lookup_robot", {
+      rrn: "RRN-000000000099",
+    })) as { status: number; error: string };
+    expect(out.status).toBe(404);
+    expect(out.error).toContain("404");
+  });
+});
+
+describe("rrf_list_registry", () => {
+  it("encodes type+limit query params", async () => {
+    let captured: string | undefined;
+    const fetchImpl: typeof fetch = vi.fn(async (url) => {
+      captured = url.toString();
+      return new Response(JSON.stringify({ entries: [] }));
+    }) as unknown as typeof fetch;
+    const client = new RrfClient({ base: "https://x", fetchImpl });
+    await callTool(client, "rrf_list_registry", { type: "robot", limit: 50 });
+    expect(captured).toContain("/v2/registry");
+    expect(captured).toContain("type=robot");
+    expect(captured).toContain("limit=50");
+  });
+
+  it("works without filters", async () => {
+    const client = new RrfClient({
+      base: "https://x",
+      fetchImpl: makeFakeFetch({
+        "/v2/registry": { body: { entries: [{ rrn: "RRN-000000000001" }] } },
+      }),
+    });
+    const out = await callTool(client, "rrf_list_registry", {});
+    expect(out).toEqual({ entries: [{ rrn: "RRN-000000000001" }] });
+  });
+});
+
+describe("rrf_fetch_spatial_eval_spec", () => {
+  it("hits /v1/spatial-eval/spec/{version}", async () => {
+    const client = new RrfClient({
+      base: "https://x",
+      fetchImpl: makeFakeFetch({
+        "/v1/spatial-eval/spec/1.0.0": {
+          body: { spec_version: "1.0.0", rrf_pubkey: "AAAA" },
+        },
+      }),
+    });
+    const out = (await callTool(client, "rrf_fetch_spatial_eval_spec", {
+      version: "1.0.0",
+    })) as { rrf_pubkey: string };
+    expect(out.rrf_pubkey).toBe("AAAA");
+  });
+});
+
+describe("rrf_fetch_spatial_eval_run (Bearer-gated)", () => {
+  it("sends Authorization: Bearer when api key is configured", async () => {
+    let captured: Headers | undefined;
+    const fetchImpl: typeof fetch = vi.fn(async (_url, init) => {
+      captured = new Headers(init?.headers);
+      return new Response(JSON.stringify({ submission_id: "sub_x", status: "pending" }));
+    }) as unknown as typeof fetch;
+    const client = new RrfClient({ base: "https://x", apiKey: "k1", fetchImpl });
+    await callTool(client, "rrf_fetch_spatial_eval_run", { submission_id: "sub_abc" });
+    expect(captured?.get("authorization")).toBe("Bearer k1");
+  });
+
+  it("returns an error envelope when no api key is configured", async () => {
+    const client = new RrfClient({ base: "https://x", fetchImpl: makeFakeFetch({}) });
+    const out = (await callTool(client, "rrf_fetch_spatial_eval_run", {
+      submission_id: "sub_abc",
+    })) as { error: string };
+    expect(out.error).toContain("Bearer-gated");
+  });
+});
+
+describe("RrfHttpError", () => {
+  it("formats the URL and status into the message", () => {
+    const e = new RrfHttpError(403, "https://x/y", { error: "nope" });
+    expect(e.message).toContain("403");
+    expect(e.message).toContain("https://x/y");
+  });
+});

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/mcp/vitest.config.ts
+++ b/mcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Spike summary

Half-day exploration of an MCP server for the Robot Registry Foundation. Read-only tools wrapping the public RRF endpoints, copy-pasteable connection recipes for all four Anthropic surfaces. **Drafted, not for merge yet** — looking for go/no-go on shape and graduation path.

## Tools shipped

| Tool | Endpoint | Auth |
|---|---|---|
| \`rrf_lookup_robot(rrn)\` | \`GET /v2/robots/{rrn}\` | public |
| \`rrf_list_registry(type?, limit?)\` | \`GET /v2/registry\` | public |
| \`rrf_fetch_spatial_eval_spec(version)\` | \`GET /v1/spatial-eval/spec/{v}\` | public |
| \`rrf_fetch_spatial_eval_run(submission_id)\` | \`GET /v1/spatial-eval/runs/{id}\` | Bearer |
| \`rrf_fetch_fria(rrn)\` | \`GET /v2/robots/{rrn}/fria\` | Bearer |

10 vitest cases passing. Stdio transport (works for Claude Desktop, Claude Code, Claude Agent SDK out of the box; claude.ai Custom Connector needs StreamableHTTP — flagged as a one-evening follow-up).

## What's NOT in this spike

- **Write tools** (register, submit-fria, submit-score, etc.) — need apikey-bound trust + a config UX. Each one is a parallel of the public-side robot-md CLI command. Belongs in the next iteration once the read-only surface is validated.
- **StreamableHTTP transport** for claude.ai web — same surface, different transport.
- **Caching** for spec/pubkey responses.

## Three decisions for you

1. **Graduate to its own repo?** Currently nested at \`mcp/\` in the website repo. Easy to extract later. Threshold: when we add write tools, the surface area justifies its own repo (own release cadence, npm publish, etc.). For now nested keeps friction low.
2. **Public package name?** When we publish to npm, suggest \`@rrf/mcp\` (current placeholder) or \`rrf-mcp-server\` for unscoped install ergonomics.
3. **Auth model for write tools?** Same Bearer apikey pattern as §22-26, or a more interactive flow (browser-based OAuth a la Cloudflare's \`wrangler login\`)?

## Test plan

- [x] \`npx vitest run --config vitest.config.ts\` (mcp/) — 10/10
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` (root, Astro) — still clean
- [x] \`npx vitest run\` (root) — 190/190 still pass
- [ ] Manual smoke: \`claude_desktop_config.json\` + Claude Desktop running locally + ask \"What robots are in the RRF registry?\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)