### PR TITLE
fix(rrf): trim whitespace from RRF_SPATIAL_EVAL_PQ_PRIV before atob

### DIFF
--- a/functions/v1/spatial-eval/_lib/score-sign.test.ts
+++ b/functions/v1/spatial-eval/_lib/score-sign.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { generateMlDsaKeypair, verifyMlDsa } from "rcan-ts";
+import { counterSignScore } from "./score-sign.js";
+import { payloadBytes } from "./score-canonical.js";
+
+function toBase64(bytes: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+
+const MIN_SCORE = {
+  spec_version: "1.0.0",
+  rrn: "RRN-000000000002",
+  run_id: "r-1",
+  rcan_signature: "rcan-sig",
+  rrf_signature: null,
+};
+
+describe("counterSignScore", () => {
+  it("signs and produces a verifiable rrf_signature", () => {
+    const kp = generateMlDsaKeypair();
+    const env = { RRF_SPATIAL_EVAL_PQ_PRIV: toBase64(kp.privateKey) };
+    const out = counterSignScore({ ...MIN_SCORE }, env);
+    const sig = Uint8Array.from(atob(out.rrf_signature as string), (c) =>
+      c.charCodeAt(0),
+    );
+    expect(verifyMlDsa(kp.publicKey, payloadBytes(out), sig)).toBe(true);
+  });
+
+  it("trims a trailing newline from the secret before decoding", () => {
+    // Reproduces the production bug where `cat priv.txt | wrangler secret put`
+    // captured a trailing \n, which atob() then rejected.
+    const kp = generateMlDsaKeypair();
+    const env = { RRF_SPATIAL_EVAL_PQ_PRIV: toBase64(kp.privateKey) + "\n" };
+    expect(() => counterSignScore({ ...MIN_SCORE }, env)).not.toThrow();
+  });
+
+  it("trims surrounding whitespace generally", () => {
+    const kp = generateMlDsaKeypair();
+    const env = {
+      RRF_SPATIAL_EVAL_PQ_PRIV: "  \n\t" + toBase64(kp.privateKey) + "\r\n  ",
+    };
+    expect(() => counterSignScore({ ...MIN_SCORE }, env)).not.toThrow();
+  });
+
+  it("throws when the secret is unset", () => {
+    expect(() => counterSignScore({ ...MIN_SCORE }, {})).toThrow(
+      /RRF_SPATIAL_EVAL_PQ_PRIV secret is not set/,
+    );
+  });
+});

--- a/functions/v1/spatial-eval/_lib/score-sign.ts
+++ b/functions/v1/spatial-eval/_lib/score-sign.ts
@@ -39,7 +39,11 @@ export function counterSignScore(
   if (!privB64) {
     throw new Error("RRF_SPATIAL_EVAL_PQ_PRIV secret is not set");
   }
-  const priv = fromBase64(privB64);
+  // Wrangler's `secret put` over piped stdin captures any trailing
+  // newline into the stored value. atob() rejects that whitespace, so
+  // trim before decoding. Defensive against any whitespace in the
+  // base64 payload, regardless of how the secret was loaded.
+  const priv = fromBase64(privB64.trim());
   const sig = signMlDsa(priv, payloadBytes(score));
   return { ...score, rrf_signature: toBase64(sig) };
 }


### PR DESCRIPTION
## Summary

End-to-end Plan B smoke against the live §27 endpoint (merged in #73) failed with:

> 500: \`atob() called with invalid base64-encoded data. (Only whitespace, '+', '/', alphanumeric ASCII, and up to two terminal '=' signs)\`

Root cause: \`cat priv.txt | wrangler secret put\` captured a trailing newline into the stored value. \`atob()\` rejects that whitespace.

Fix: \`.trim()\` the secret before decoding. Defensive against any surrounding whitespace, regardless of how the secret was loaded.

4 vitest cases including a direct regression test for the trailing-newline shape.

## Test plan

- [x] \`npx vitest run functions/v1/spatial-eval/_lib/score-sign.test.ts\` — 4/4 pass
- [ ] Merge → Cloudflare Pages auto-deploy → re-run end-to-end smoke against \`POST /v1/spatial-eval/runs\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)