### PR TITLE
feat(v2/authorities): add RAN namespace for non-robot signing identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,29 @@ The open registry for RCAN-compliant robots — assigns permanent global identit
 
 Full API reference: [robotregistryfoundation.org/api/](https://robotregistryfoundation.org/api/)
 
+## Identity Namespaces
+
+RRF assigns globally unique identifiers across five namespaces. All identifiers use a 12-digit zero-padded format.
+
+| Namespace | Format | What It Identifies |
+|---|---|---|
+| **RRN** — Robot Registration Number | `RRN-000000000001` | A physical or virtual robot |
+| **RCN** — Robot Component Number | `RCN-000000000001` | A hardware component of a registered robot |
+| **RMN** — Robot Model Number | `RMN-000000000001` | An AI model registered for robot use |
+| **RHN** — Robot Harness Number | `RHN-000000000001` | An AI harness/agent framework |
+| **RAN** — Robot Authority Number | `RAN-000000000001` | A non-robot signing authority (aggregators, release-signing tools, attestation services, policy authorities) |
+
+- **RAN — Robot Authority Number.** Identity for non-robot, non-component, non-model entities that need durable hybrid keys: aggregators, release-signing tools, attestation services, policy authorities. Endpoint: `/v2/authorities/<ran>`. Registered via §2.2 ritual at `/v2/authorities/register`.
+
+### Authority (RAN) Endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/v2/authorities/register` | Register a new RAN (§2.2 hybrid-signed) |
+| `GET` | `/v2/authorities/<ran>` | Fetch a single authority record |
+| `GET` | `/v2/authorities` | List all registered authorities (paginated) |
+| `DELETE` | `/v2/authorities/<ran>` | Admin-only removal (`RRF_ADMIN_TOKEN` required) |
+
 ## Compliance Intake (RCAN §22-26)
 
 Robots registered under [`/v2/robots/register`](#registration) can submit EU AI Act compliance artifacts produced by the [`rcan-ts`](https://www.npmjs.com/package/rcan-ts) 3.3.0+ builders.

--- a/functions/v2/_lib/types.ts
+++ b/functions/v2/_lib/types.ts
@@ -104,10 +104,35 @@ export interface HarnessRecord {
   owner_uid?: string;
 }
 
+// ── Robot Authority Number ────────────────────────────────────────────────────
+export type RanString = `RAN-${string}`;
+
+export type AuthorityPurpose =
+  | "compatibility-matrix-aggregate"
+  | "release-signing"
+  | "attestation"
+  | "policy"
+  | "other";
+
+export interface AuthorityRecord {
+  ran: RanString;
+  organization: string;
+  display_name: string;
+  purpose: AuthorityPurpose;
+  signing_pub: string;                   // Ed25519 raw public key, base64
+  pq_signing_pub: string;                // ML-DSA-65 raw public key, base64
+  pq_kid: string;
+  signing_alg: ["Ed25519", "ML-DSA-65"]; // tuple, locked
+  registered_at: string;                 // RFC 3339 UTC
+  status: "active" | "revoked";
+  revoked_at?: string;
+  revocation_reason?: string;
+}
+
 // ── Unified listing ───────────────────────────────────────────────────────────
 export interface RegistryEntry {
-  id: string;           // RRN, RCN, RMN, or RHN
-  entity_type: "robot" | "component" | "model" | "harness";
+  id: string;           // RRN, RCN, RMN, RHN, or RAN
+  entity_type: "robot" | "component" | "model" | "harness" | "authority";
   name: string;
   registered_at: string;
   summary: Record<string, unknown>;

--- a/functions/v2/authorities/[ran]/index.ts
+++ b/functions/v2/authorities/[ran]/index.ts
@@ -1,0 +1,44 @@
+/**
+ * GET  /v2/authorities/:ran — fetch a single AuthorityRecord by RAN.
+ * DELETE /v2/authorities/:ran — admin-only soft-delete (removes from KV).
+ */
+
+import type { AuthorityRecord } from "../../_lib/types.js";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+  RRF_ADMIN_TOKEN?: string;
+}
+
+const isRan = (s: string) => /^RAN-\d{12}$/.test(s);
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env> = async ({ params, env }) => {
+  const ran = String(params.ran ?? "");
+  if (!isRan(ran)) return json({ error: "invalid RAN format" }, 400);
+  const raw = await env.RRF_KV.get(`authority:${ran}`, "text");
+  if (!raw) return json({ error: "RAN not found" }, 404);
+  return new Response(raw, {
+    status: 200,
+    headers: { "Content-Type": "application/json", "Cache-Control": "public, max-age=300" },
+  });
+};
+
+export const onRequestDelete: PagesFunction<Env> = async ({ params, env, request }) => {
+  const auth = request.headers.get("Authorization") ?? "";
+  if (!env.RRF_ADMIN_TOKEN || auth !== `Bearer ${env.RRF_ADMIN_TOKEN}`) {
+    return json({ error: "unauthorized" }, 401);
+  }
+  const ran = String(params.ran ?? "");
+  if (!isRan(ran)) return json({ error: "invalid RAN format" }, 400);
+  const raw = await env.RRF_KV.get(`authority:${ran}`, "text");
+  if (!raw) return json({ error: "RAN not found" }, 404);
+  await env.RRF_KV.delete(`authority:${ran}`);
+  return json({ status: "deleted", ran }, 200);
+};

--- a/functions/v2/authorities/[ran]/index.ts
+++ b/functions/v2/authorities/[ran]/index.ts
@@ -1,6 +1,8 @@
 /**
  * GET  /v2/authorities/:ran — fetch a single AuthorityRecord by RAN.
- * DELETE /v2/authorities/:ran — admin-only soft-delete (removes from KV).
+ * DELETE /v2/authorities/:ran — admin-only revocation (sets status to 'revoked',
+ *   preserves the record for transparency log). Identity registries must retain
+ *   records; hard deletes are not permitted.
  */
 
 import type { AuthorityRecord } from "../../_lib/types.js";
@@ -31,14 +33,35 @@ export const onRequestGet: PagesFunction<Env> = async ({ params, env }) => {
 };
 
 export const onRequestDelete: PagesFunction<Env> = async ({ params, env, request }) => {
+  // Admin-token gated. Soft-delete: sets status to "revoked"; record persists.
   const auth = request.headers.get("Authorization") ?? "";
   if (!env.RRF_ADMIN_TOKEN || auth !== `Bearer ${env.RRF_ADMIN_TOKEN}`) {
     return json({ error: "unauthorized" }, 401);
   }
   const ran = String(params.ran ?? "");
   if (!isRan(ran)) return json({ error: "invalid RAN format" }, 400);
-  const raw = await env.RRF_KV.get(`authority:${ran}`, "text");
+
+  const raw = await env.RRF_KV.get(`authority:${ran}`);
   if (!raw) return json({ error: "RAN not found" }, 404);
-  await env.RRF_KV.delete(`authority:${ran}`);
-  return json({ status: "deleted", ran }, 200);
+  const rec = JSON.parse(raw) as AuthorityRecord;
+  if (rec.status === "revoked") return json({ error: "already revoked", record: rec }, 409);
+
+  // Allow operator to pass a reason via query param OR JSON body.
+  const url = new URL(request.url);
+  let reason = url.searchParams.get("reason") ?? undefined;
+  if (!reason) {
+    try {
+      const body = await request.clone().json() as { reason?: string };
+      reason = body?.reason;
+    } catch { /* no body or non-JSON body — fine, reason stays undefined */ }
+  }
+
+  const updated: AuthorityRecord = {
+    ...rec,
+    status: "revoked",
+    revoked_at: new Date().toISOString(),
+    ...(reason ? { revocation_reason: reason } : {}),
+  };
+  await env.RRF_KV.put(`authority:${ran}`, JSON.stringify(updated));
+  return json({ status: "revoked", record: updated }, 200);
 };

--- a/functions/v2/authorities/index.ts
+++ b/functions/v2/authorities/index.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /v2/authorities — paginated list of registered RAN authorities.
+ *
+ * Query params:
+ *   cursor?  pagination cursor from previous response
+ *   limit?   max results (default 50, max 200)
+ *
+ * Returns: { entries[], next_cursor }
+ */
+
+import type { AuthorityRecord } from "../_lib/types.js";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+}
+
+export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
+  const url = new URL(request.url);
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+  const rawLimit = parseInt(url.searchParams.get("limit") ?? "50", 10);
+  const limit = Math.min(isNaN(rawLimit) ? 50 : rawLimit, 200);
+
+  const list = await env.RRF_KV.list({ prefix: "authority:RAN-", cursor, limit });
+
+  const entries = [];
+  for (const k of list.keys) {
+    const raw = await env.RRF_KV.get(k.name, "text");
+    if (!raw) continue;
+    const rec = JSON.parse(raw) as AuthorityRecord;
+    // Return a summary — omit signing keys from list view
+    entries.push({
+      ran: rec.ran,
+      organization: rec.organization,
+      display_name: rec.display_name,
+      purpose: rec.purpose,
+      registered_at: rec.registered_at,
+      status: rec.status,
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      entries,
+      next_cursor: list.list_complete ? null : (list as any).cursor ?? null,
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=60",
+      },
+    },
+  );
+};

--- a/functions/v2/authorities/register.ts
+++ b/functions/v2/authorities/register.ts
@@ -104,7 +104,16 @@ export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
     return json({ error: "Signature verification failed (§2.2)" }, 400);
   }
 
-  // pq_kid uniqueness within RAN namespace
+  // pq_kid uniqueness within the RAN namespace.
+  //
+  // Other RRF namespaces don't enforce kid uniqueness; RAN does because release-signing
+  // authorities are looked up by both RAN AND kid in downstream verifiers (e.g., compatibility
+  // matrix), and kid collisions across authorities would let a verifier cache the wrong key.
+  //
+  // Race-condition note: under concurrent POSTs, both can pass this scan before either
+  // writes. Cloudflare KV is eventually-consistent; atomic check-and-set is not available.
+  // Acceptable at current traffic. Future hardening (transparency log, gateway-side admission)
+  // is Plan 4 scope.
   const list = await env.RRF_KV.list({ prefix: "authority:" });
   for (const k of list.keys) {
     // Skip counter key if it matches the prefix (it won't, but be safe)

--- a/functions/v2/authorities/register.ts
+++ b/functions/v2/authorities/register.ts
@@ -1,0 +1,144 @@
+/**
+ * POST /v2/authorities/register
+ * RCAN 3.0 §2.2 — Register a Robot Authority Number (RAN).
+ *
+ * RAN identifies non-robot, non-component, non-model entities that need durable
+ * hybrid keys: aggregators, release-signing tools, attestation services,
+ * policy authorities.
+ *
+ * Body: { organization, display_name, purpose, signing_pub, pq_signing_pub,
+ *         pq_kid, signing_alg, sig: { ml_dsa, ed25519, ed25519_pub } }
+ *
+ * Returns: { ran, status, registered_at }
+ */
+
+import type { AuthorityRecord, AuthorityPurpose } from "../_lib/types.js";
+import { verifyBody } from "rcan-ts";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+}
+
+const ALLOWED_PURPOSES: AuthorityPurpose[] = [
+  "compatibility-matrix-aggregate",
+  "release-signing",
+  "attestation",
+  "policy",
+  "other",
+];
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
+  let body: Record<string, unknown>;
+  try {
+    body = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: "invalid JSON" }, 400);
+  }
+
+  // Required field check
+  const required = [
+    "organization",
+    "display_name",
+    "purpose",
+    "signing_pub",
+    "pq_signing_pub",
+    "pq_kid",
+    "signing_alg",
+    "sig",
+  ] as const;
+  for (const k of required) {
+    if (body[k] === undefined || body[k] === null) {
+      return json({ error: `${k} required` }, 400);
+    }
+  }
+
+  // signing_alg must be exactly ["Ed25519", "ML-DSA-65"]
+  if (
+    !Array.isArray(body.signing_alg) ||
+    body.signing_alg[0] !== "Ed25519" ||
+    body.signing_alg[1] !== "ML-DSA-65"
+  ) {
+    return json({ error: 'signing_alg must be ["Ed25519", "ML-DSA-65"]' }, 400);
+  }
+
+  // Validate purpose
+  if (!ALLOWED_PURPOSES.includes(body.purpose as AuthorityPurpose)) {
+    return json(
+      { error: `purpose must be one of ${ALLOWED_PURPOSES.join("|")}` },
+      400,
+    );
+  }
+
+  // sig fields must all be present
+  const sig = body.sig as Record<string, unknown> | undefined;
+  if (!sig || !sig.ml_dsa || !sig.ed25519 || !sig.ed25519_pub) {
+    return json({ error: "sig.ml_dsa, sig.ed25519, sig.ed25519_pub all required" }, 400);
+  }
+
+  // Validate that sig.ed25519_pub matches signing_pub (proves possession)
+  if (sig.ed25519_pub !== body.signing_pub) {
+    return json(
+      { error: "ed25519_pub in sig must match signing_pub field" },
+      400,
+    );
+  }
+
+  // §2.2 hybrid signature verification via rcan-ts verifyBody
+  let verified = false;
+  try {
+    const pqPub = Uint8Array.from(atob(body.pq_signing_pub as string), (c) =>
+      c.charCodeAt(0),
+    );
+    verified = await verifyBody(body as any, pqPub);
+  } catch {
+    /* verified stays false */
+  }
+  if (!verified) {
+    return json({ error: "Signature verification failed (§2.2)" }, 400);
+  }
+
+  // pq_kid uniqueness within RAN namespace
+  const list = await env.RRF_KV.list({ prefix: "authority:" });
+  for (const k of list.keys) {
+    // Skip counter key if it matches the prefix (it won't, but be safe)
+    if (!k.name.startsWith("authority:RAN-")) continue;
+    const raw = await env.RRF_KV.get(k.name, "text");
+    if (!raw) continue;
+    const rec = JSON.parse(raw) as AuthorityRecord;
+    if (rec.pq_kid === body.pq_kid) {
+      return json({ error: "pq_kid duplicate within RAN namespace" }, 409);
+    }
+  }
+
+  // Sequential RAN assignment (counter:ran mirrors counter:rrn, counter:rcn, etc.)
+  const counterStr = await env.RRF_KV.get("counter:ran", "text");
+  const next = (counterStr ? parseInt(counterStr, 10) : 0) + 1;
+  const ran = `RAN-${String(next).padStart(12, "0")}` as `RAN-${string}`;
+
+  const record: AuthorityRecord = {
+    ran,
+    organization: body.organization as string,
+    display_name: body.display_name as string,
+    purpose: body.purpose as AuthorityPurpose,
+    signing_pub: body.signing_pub as string,
+    pq_signing_pub: body.pq_signing_pub as string,
+    pq_kid: body.pq_kid as string,
+    signing_alg: ["Ed25519", "ML-DSA-65"],
+    registered_at: new Date().toISOString(),
+    status: "active",
+  };
+
+  await env.RRF_KV.put(`authority:${ran}`, JSON.stringify(record), {
+    expirationTtl: 365 * 24 * 3600 * 10,
+  });
+  await env.RRF_KV.put("counter:ran", String(next));
+
+  return json({ ran, status: "active", registered_at: record.registered_at }, 201);
+};

--- a/functions/v2/registry/index.ts
+++ b/functions/v2/registry/index.ts
@@ -18,6 +18,7 @@ const PREFIXES: Array<{ prefix: string; type: RegistryEntry["entity_type"]; kvKe
   { prefix: "RCN",     type: "component", kvKey: "component:" },
   { prefix: "RMN",     type: "model",     kvKey: "model:" },
   { prefix: "RHN",     type: "harness",   kvKey: "harness:" },
+  { prefix: "RAN",     type: "authority", kvKey: "authority:RAN-" },
 ];
 
 export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
@@ -32,13 +33,13 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
 
   if (typeFilter && prefixesToScan.length === 0) {
     return new Response(
-      JSON.stringify({ error: "Invalid type. Must be: robot, component, model, harness" }),
+      JSON.stringify({ error: "Invalid type. Must be: robot, component, model, harness, authority" }),
       { status: 400, headers: { "Content-Type": "application/json" } },
     );
   }
 
   const entries: RegistryEntry[] = [];
-  const counts: Record<string, number> = { robot: 0, component: 0, model: 0, harness: 0 };
+  const counts: Record<string, number> = { robot: 0, component: 0, model: 0, harness: 0, authority: 0 };
 
   for (const { type, kvKey } of prefixesToScan) {
     const list = await env.RRF_KV.list({ prefix: kvKey, limit: 200 });
@@ -82,7 +83,7 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
 };
 
 function summarize(record: Record<string, unknown>, type: RegistryEntry["entity_type"]): RegistryEntry {
-  const id = (record.rrn ?? record.rcn ?? record.rmn ?? record.rhn) as string;
+  const id = (record.rrn ?? record.rcn ?? record.rmn ?? record.rhn ?? record.ran) as string;
   let name = "";
   let summary: Record<string, unknown> = {};
 
@@ -112,6 +113,11 @@ function summarize(record: Record<string, unknown>, type: RegistryEntry["entity_
       }
       summary = { harness_type: record.harness_type, rcan_version: record.rcan_version,
                   open_source: record.open_source };
+      break;
+    case "authority":
+      name = record.display_name as string;
+      summary = { organization: record.organization, purpose: record.purpose,
+                  status: record.status };
       break;
   }
 

--- a/tests/api/v2/authorities.test.ts
+++ b/tests/api/v2/authorities.test.ts
@@ -1,0 +1,242 @@
+/**
+ * /v2/authorities — RAN namespace tests
+ *
+ * Uses the same direct-function-import harness as functions/v2/components/register.test.ts.
+ * Signing is done via rcan-ts signBody + makeTestKeypair from the shared test helper.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { onRequestPost } from "../../../functions/v2/authorities/register.js";
+import { onRequestGet as onGetSingle, onRequestDelete } from "../../../functions/v2/authorities/[ran]/index.js";
+import { onRequestGet as onGetList } from "../../../functions/v2/authorities/index.js";
+import { signBody } from "rcan-ts";
+import { makeTestKeypair } from "../../../functions/v2/_lib/test-helpers.js";
+
+// ── Shared KV mock ────────────────────────────────────────────────────────────
+
+function makeEnv(adminToken?: string) {
+  const store: Record<string, string> = {};
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+      list: vi.fn(async (opts: { prefix?: string; cursor?: string; limit?: number }) => {
+        const prefix = opts?.prefix ?? "";
+        const matching = Object.keys(store)
+          .filter((k) => k.startsWith(prefix))
+          .map((name) => ({ name }));
+        return { keys: matching, list_complete: true };
+      }),
+      delete: vi.fn(async (k: string) => { delete store[k]; }),
+    } as unknown as KVNamespace,
+    RRF_ADMIN_TOKEN: adminToken,
+    __store: store,
+  };
+}
+
+function makeReq(method: string, url: string, body?: unknown, headers: Record<string, string> = {}): Request {
+  return new Request(url, {
+    method,
+    headers: { "Content-Type": "application/json", ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ── Sign a registration body ─────────────────────────────────────────────────
+
+type TestKp = Awaited<ReturnType<typeof makeTestKeypair>>;
+
+async function buildSignedRegistration(
+  meta: { organization: string; display_name: string; purpose: string },
+  kp?: TestKp,
+) {
+  const keypair = kp ?? await makeTestKeypair();
+  const b64 = (b: Uint8Array) => btoa(String.fromCharCode(...b));
+  const ed25519PubB64 = b64(keypair.ed25519Public);
+  // Include signing_pub and signing_alg in the body BEFORE signing so they
+  // are part of the canonical message that verifyBody checks.
+  const bodyToSign = {
+    ...meta,
+    signing_pub: ed25519PubB64,
+    signing_alg: ["Ed25519", "ML-DSA-65"],
+  };
+  const signed = await signBody(keypair.mlDsa, bodyToSign as any, {
+    ed25519Secret: keypair.ed25519Secret,
+    ed25519Public: keypair.ed25519Public,
+  });
+  return signed;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("/v2/authorities — RAN namespace", () => {
+  it("POST /v2/authorities/register creates a new RAN with hybrid keys (201)", async () => {
+    const env = makeEnv();
+    const body = await buildSignedRegistration({
+      organization: "OpenCastor (the company)",
+      display_name: "Test aggregator",
+      purpose: "compatibility-matrix-aggregate",
+    });
+    const res = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", body),
+      env,
+    } as any);
+    expect(res.status).toBe(201);
+    const out = await res.json() as any;
+    expect(out.ran).toMatch(/^RAN-\d{12}$/);
+    expect(out.status).toBe("active");
+    expect(out.registered_at).toBeTruthy();
+  });
+
+  it("GET /v2/authorities/<ran> returns the persisted record (200)", async () => {
+    const env = makeEnv();
+    // Register one first
+    const body = await buildSignedRegistration({
+      organization: "OpenCastor (the company)",
+      display_name: "Aggregator for GET test",
+      purpose: "attestation",
+    });
+    const postRes = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", body),
+      env,
+    } as any);
+    expect(postRes.status).toBe(201);
+    const { ran } = await postRes.json() as any;
+
+    const getRes = await onGetSingle({
+      params: { ran },
+      env,
+      request: makeReq("GET", `https://x/v2/authorities/${ran}`),
+    } as any);
+    expect(getRes.status).toBe(200);
+    const out = await getRes.json() as any;
+    expect(out.ran).toBe(ran);
+    expect(out.signing_alg).toEqual(["Ed25519", "ML-DSA-65"]);
+    expect(out.pq_signing_pub).toBeTruthy();
+    expect(out.signing_pub).toBeTruthy();
+    expect(out.status).toBe("active");
+  });
+
+  it("POST rejects registration with mismatched signing_pub vs sig.ed25519_pub (400)", async () => {
+    const env = makeEnv();
+    const body = await buildSignedRegistration({
+      organization: "test", display_name: "test", purpose: "other",
+    });
+    // Tamper signing_pub to a different key
+    const kp2 = await makeTestKeypair();
+    const tampered = { ...body, signing_pub: btoa(String.fromCharCode(...kp2.ed25519Public)) };
+    const res = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", tampered),
+      env,
+    } as any);
+    expect(res.status).toBe(400);
+    const out = await res.json() as any;
+    expect(out.error).toMatch(/ed25519/i);
+  });
+
+  it("POST rejects registration without pq_signing_pub (400)", async () => {
+    const env = makeEnv();
+    const res = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", {
+        organization: "x",
+        display_name: "x",
+        purpose: "other",
+        signing_alg: ["Ed25519", "ML-DSA-65"],
+        pq_kid: "x",
+        signing_pub: "x",
+        sig: { ml_dsa: "x", ed25519: "x", ed25519_pub: "x" },
+        // pq_signing_pub deliberately omitted
+      }),
+      env,
+    } as any);
+    expect(res.status).toBe(400);
+    const out = await res.json() as any;
+    expect(out.error).toMatch(/pq_signing_pub.*required/i);
+  });
+
+  it("POST rejects duplicate pq_kid within RAN namespace (409)", async () => {
+    const env = makeEnv();
+    // Both registrations share the same ML-DSA keypair → same pq_kid (computed hash).
+    const sharedKp = await makeTestKeypair();
+    const b1 = await buildSignedRegistration(
+      { organization: "x", display_name: "x", purpose: "other" },
+      sharedKp,
+    );
+    const r1 = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", b1),
+      env,
+    } as any);
+    expect(r1.status).toBe(201);
+
+    // Second registration reuses same keypair → same pq_kid → duplicate
+    const b2 = await buildSignedRegistration(
+      { organization: "y", display_name: "y", purpose: "other" },
+      sharedKp,
+    );
+    const r2 = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", b2),
+      env,
+    } as any);
+    expect(r2.status).toBe(409);
+    const out = await r2.json() as any;
+    expect(out.error).toMatch(/pq_kid.*duplicate/i);
+  });
+
+  it("GET /v2/authorities lists registered authorities (200)", async () => {
+    const env = makeEnv();
+    // Register one
+    const body = await buildSignedRegistration({
+      organization: "ListOrg", display_name: "List test authority", purpose: "policy",
+    });
+    const postRes = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", body),
+      env,
+    } as any);
+    expect(postRes.status).toBe(201);
+    const { ran } = await postRes.json() as any;
+
+    const listRes = await onGetList({
+      env,
+      request: makeReq("GET", "https://x/v2/authorities"),
+    } as any);
+    expect(listRes.status).toBe(200);
+    const out = await listRes.json() as any;
+    expect(Array.isArray(out.entries)).toBe(true);
+    expect(out.entries.some((e: any) => e.ran === ran)).toBe(true);
+  });
+
+  it("DELETE /v2/authorities/<ran> requires admin token (401 without, 200 with)", async () => {
+    const adminToken = "test-admin-token-xyz";
+    const env = makeEnv(adminToken);
+    // Register one
+    const body = await buildSignedRegistration({
+      organization: "DeleteOrg", display_name: "Delete test", purpose: "other",
+    });
+    const postRes = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", body),
+      env,
+    } as any);
+    expect(postRes.status).toBe(201);
+    const { ran } = await postRes.json() as any;
+
+    // Without token → 401
+    const noAuthRes = await onRequestDelete({
+      params: { ran },
+      env,
+      request: makeReq("DELETE", `https://x/v2/authorities/${ran}`),
+    } as any);
+    expect(noAuthRes.status).toBe(401);
+
+    // With token → 200
+    const authRes = await onRequestDelete({
+      params: { ran },
+      env,
+      request: makeReq("DELETE", `https://x/v2/authorities/${ran}`, undefined, {
+        Authorization: `Bearer ${adminToken}`,
+      }),
+    } as any);
+    expect(authRes.status).toBe(200);
+    const out = await authRes.json() as any;
+    expect(out.status).toBe("deleted");
+  });
+});

--- a/tests/api/v2/authorities.test.ts
+++ b/tests/api/v2/authorities.test.ts
@@ -205,7 +205,7 @@ describe("/v2/authorities — RAN namespace", () => {
     expect(out.entries.some((e: any) => e.ran === ran)).toBe(true);
   });
 
-  it("DELETE /v2/authorities/<ran> requires admin token (401 without, 200 with)", async () => {
+  it("DELETE /v2/authorities/<ran> requires admin token (401 without, 200 soft-delete with)", async () => {
     const adminToken = "test-admin-token-xyz";
     const env = makeEnv(adminToken);
     // Register one
@@ -227,7 +227,7 @@ describe("/v2/authorities — RAN namespace", () => {
     } as any);
     expect(noAuthRes.status).toBe(401);
 
-    // With token → 200
+    // With token → 200, soft-delete (status = "revoked", record preserved)
     const authRes = await onRequestDelete({
       params: { ran },
       env,
@@ -237,6 +237,52 @@ describe("/v2/authorities — RAN namespace", () => {
     } as any);
     expect(authRes.status).toBe(200);
     const out = await authRes.json() as any;
-    expect(out.status).toBe("deleted");
+    expect(out.status).toBe("revoked");
+    expect(out.record).toBeDefined();
+    expect(out.record.status).toBe("revoked");
+    expect(out.record.revoked_at).toBeTruthy();
+
+    // GET on the same RAN returns 200 with status = "revoked" (proves record persists)
+    const getAfterRes = await onGetSingle({
+      params: { ran },
+      env,
+      request: makeReq("GET", `https://x/v2/authorities/${ran}`),
+    } as any);
+    expect(getAfterRes.status).toBe(200);
+    const getAfterOut = await getAfterRes.json() as any;
+    expect(getAfterOut.status).toBe("revoked");
+
+    // DELETE on an already-revoked RAN → 409
+    const doubleDeleteRes = await onRequestDelete({
+      params: { ran },
+      env,
+      request: makeReq("DELETE", `https://x/v2/authorities/${ran}`, undefined, {
+        Authorization: `Bearer ${adminToken}`,
+      }),
+    } as any);
+    expect(doubleDeleteRes.status).toBe(409);
+    const ddOut = await doubleDeleteRes.json() as any;
+    expect(ddOut.error).toMatch(/already revoked/i);
+  });
+
+  it("POST rejects registration with cryptographically invalid signature", async () => {
+    // Build a valid body, then corrupt the sig.ml_dsa bytes so verifyBody detects
+    // that the signature doesn't verify against pq_signing_pub.
+    const env = makeEnv();
+    const body = await buildSignedRegistration({
+      organization: "test", display_name: "test", purpose: "other",
+    }) as Record<string, any>;
+
+    // Tamper: corrupt a byte in sig.ml_dsa (the ML-DSA signature is what verifyBody checks).
+    const sigBytes = Buffer.from(body.sig.ml_dsa, "base64");
+    sigBytes[0] ^= 0xff;  // flip bits in the first byte
+    body.sig = { ...body.sig, ml_dsa: sigBytes.toString("base64") };
+
+    const r = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", body),
+      env,
+    } as any);
+    expect(r.status).toBe(400);
+    expect((await r.json() as any).error).toMatch(/sig|invalid|verif/i);
   });
 });


### PR DESCRIPTION
Adds top-level RAN namespace + 4 endpoints. KV storage at \`authority:{RAN}\`. Mirrors RCN §2.2 registration ritual.

## Summary

- New `AuthorityRecord` interface + `RanString` type alias + `AuthorityPurpose` enum in `_lib/types.ts`
- POST `/v2/authorities/register` — §2.2 hybrid-signed (ML-DSA-65 + Ed25519) registration; assigns sequential RAN, checks `pq_kid` uniqueness (409 on dup)
- GET `/v2/authorities/<ran>` — single record fetch
- GET `/v2/authorities` — paginated list (summary view, no signing keys)
- DELETE `/v2/authorities/<ran>` — `RRF_ADMIN_TOKEN`-gated removal
- `/v2/registry` aggregate now counts `authority` entity type
- 7 new tests; 220/220 total pass

Pulls forward a small piece of Plan 4 RRF endpoint work to unblock Plan 1 Phase 0 Task 2 (OpenCastor aggregator RAN registration).

New namespace; existing RRN/RCN/RMN/RHN handlers and data unchanged. No `_lib/verify.ts` extraction needed — §2.2 verification is already in `rcan-ts` as `verifyBody()`.

## Test plan

- [x] `pnpm exec vitest run tests/api/v2/authorities.test.ts` — 7 PASS
- [x] `pnpm exec vitest run` — 220/220 PASS (no regressions)
- [ ] After merge + deploy: POST a signed body to `https://robotregistryfoundation.org/v2/authorities/register` and confirm 201 + valid RAN (Task 2 Step 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)