### PR TITLE
api(v2): GET+POST /compatibility-matrix endpoint (Plan 1 Task 16)

### DIFF
--- a/functions/v2/_lib/types.ts
+++ b/functions/v2/_lib/types.ts
@@ -129,6 +129,29 @@ export interface AuthorityRecord {
   revocation_reason?: string;
 }
 
+// ── Version-tuple envelope (hybrid-signed wrapper) ────────────────────────────
+/**
+ * Version-tuple envelope (hybrid-signed wrapper) — matches rcan-spec
+ * /schemas/version-tuple-envelope.json verbatim. Per RCAN v3.2 Decision 3
+ * (pqc-hybrid-v1): signature_mldsa65 is REQUIRED; signature_ed25519 is
+ * OPTIONAL but if present must verify and must be paired with `kid`.
+ *
+ * The aggregator (monitor.version_matrix.sign_matrix in opencastor-ops)
+ * produces this exact shape. The compatibility-matrix endpoint reuses
+ * the same envelope schema (the matrix IS a version-tuple payload, just
+ * with a richer inner structure than per-field tuples).
+ */
+export interface VersionTupleEnvelope {
+  ran: string;                       // RAN-NNNNNNNNNNNN — direct authority lookup
+  alg: ["ML-DSA-65"] | ["ML-DSA-65", "Ed25519"];   // ML-DSA-65 always at index 0
+  pq_kid: string;                    // 8-hex; sha256(pq_pub)[:8].hex(); must equal authority.pq_kid
+  kid?: string;                      // 8-hex; required iff signature_ed25519 present
+  payload: string;                   // base64 (NOT base64url) of canonical-JSON inner
+  signature_mldsa65: string;         // base64 — REQUIRED
+  signature_ed25519?: string;        // base64 — OPTIONAL; if present, MUST verify
+  signed_at: string;                 // RFC 3339 UTC
+}
+
 // ── Unified listing ───────────────────────────────────────────────────────────
 export interface RegistryEntry {
   id: string;           // RRN, RCN, RMN, RHN, or RAN

--- a/functions/v2/compatibility-matrix/index.test.ts
+++ b/functions/v2/compatibility-matrix/index.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for /v2/compatibility-matrix (Plan 1 Task 16, REVISION 2).
+ *
+ * Envelope shape conforms to rcan-spec /schemas/version-tuple-envelope.json.
+ * Signature verification is exercised via a module-level mutable seam
+ * (__setVerifyEnvelopeForTests) — vi.doMock cannot swap an export that
+ * onRequestPost has already lexically captured.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  onRequestGet,
+  onRequestPost,
+  __setVerifyEnvelopeForTests,
+  __resetVerifyEnvelopeForTests,
+} from "./index";
+import type { VersionTupleEnvelope, AuthorityRecord } from "../_lib/types";
+
+const AGGREGATOR_RAN = "RAN-000000000001";
+const AGGREGATOR_PQ_KID = "8e2d0b5f";    // 8-hex; matches test authority record
+const AGGREGATOR_KID = "ede25091";       // Ed25519 kid; same shape as real
+
+function makeKV(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    put: vi.fn(async (k: string, v: string, _opts?: any) => { store.set(k, v); }),
+    list: vi.fn(async () => ({ keys: Array.from(store.keys()).map(name => ({ name })) })),
+    _store: store,
+  };
+}
+
+function makeAuthority(overrides: Partial<AuthorityRecord> = {}): AuthorityRecord {
+  return {
+    ran: AGGREGATOR_RAN as `RAN-${string}`,
+    organization: "OpenCastor (the company)",
+    display_name: "OpenCastor compatibility-matrix aggregator",
+    purpose: "compatibility-matrix-aggregate",
+    signing_pub: "AAAA",  // base64; real values come from RAN registration
+    pq_signing_pub: "BBBB",
+    pq_kid: AGGREGATOR_PQ_KID,
+    signing_alg: ["Ed25519", "ML-DSA-65"],
+    registered_at: "2026-05-02T00:00:00Z",
+    status: "active",
+    ...overrides,
+  } as AuthorityRecord;
+}
+
+function makeEnvelope(overrides: Partial<VersionTupleEnvelope> = {}): VersionTupleEnvelope {
+  // Inner payload: minimal valid matrix shape.
+  const inner = {
+    matrix_version: "1.0",
+    matrix_signed_at: "2026-05-04T14:21:42Z",
+    projects: {},
+    drift: [],
+    fetch_errors: [],
+    findings: [],
+  };
+  const payload = btoa(JSON.stringify(inner));  // base64, schema-conformant
+  return {
+    ran: AGGREGATOR_RAN,
+    alg: ["ML-DSA-65", "Ed25519"],
+    pq_kid: AGGREGATOR_PQ_KID,
+    kid: AGGREGATOR_KID,
+    payload,
+    signature_mldsa65: "AAAA",
+    signature_ed25519: "BBBB",
+    signed_at: "2026-05-04T14:21:42Z",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  __resetVerifyEnvelopeForTests();
+});
+
+describe("GET /v2/compatibility-matrix", () => {
+  it("returns 503 when no matrix has been pushed yet", async () => {
+    const env = { RRF_KV: makeKV() } as any;
+    const r = await onRequestGet({ env, request: new Request("https://x/") } as any);
+    expect(r.status).toBe(503);
+    const body = await r.json() as any;
+    expect(body.error.toLowerCase()).toContain("no matrix");
+  });
+
+  it("returns the latest stored envelope as-is", async () => {
+    const stored = makeEnvelope({ ran: AGGREGATOR_RAN });
+    const env = { RRF_KV: makeKV({
+      "compatibility-matrix:latest": JSON.stringify(stored),
+    }) } as any;
+    const r = await onRequestGet({ env, request: new Request("https://x/") } as any);
+    expect(r.status).toBe(200);
+    const body = await r.json() as any;
+    expect(body.ran).toBe(AGGREGATOR_RAN);
+    expect(body.alg).toEqual(["ML-DSA-65", "Ed25519"]);
+    expect(body.signature_mldsa65).toBeDefined();
+  });
+});
+
+describe("POST /v2/compatibility-matrix", () => {
+  it("rejects 400 when body is not valid JSON", async () => {
+    const env = { RRF_KV: makeKV() } as any;
+    const r = await onRequestPost({ env, request: new Request("https://x/", { method: "POST", body: "not-json" }) } as any);
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects 400 when required envelope fields are missing", async () => {
+    const env = { RRF_KV: makeKV() } as any;
+    // Missing signature_mldsa65 (REQUIRED).
+    const bad = { ran: AGGREGATOR_RAN, alg: ["ML-DSA-65"], pq_kid: "deadbeef", payload: "AAAA", signed_at: "2026-05-04T00:00:00Z" };
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(bad), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects 400 when signature_ed25519 present but kid missing", async () => {
+    // dependentRequired: {signature_ed25519: ["kid"]} — schema-level invariant.
+    const env = { RRF_KV: makeKV() } as any;
+    const env_ = makeEnvelope();
+    delete (env_ as any).kid;
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(env_), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(400);  // schema violation
+  });
+
+  it("rejects 401 when ran does not resolve to a registered authority", async () => {
+    const env = { RRF_KV: makeKV() } as any;  // empty KV — RAN not found
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(makeEnvelope()), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it("rejects 401 when authority purpose != compatibility-matrix-aggregate", async () => {
+    const auth = makeAuthority({ purpose: "release-signing" });
+    const env = { RRF_KV: makeKV({ [`authority:${AGGREGATOR_RAN}`]: JSON.stringify(auth) }) } as any;
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(makeEnvelope()), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it("rejects 401 when pq_kid does not match authority.pq_kid", async () => {
+    const auth = makeAuthority({ pq_kid: "deadbeef" });
+    const env = { RRF_KV: makeKV({ [`authority:${AGGREGATOR_RAN}`]: JSON.stringify(auth) }) } as any;
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(makeEnvelope()), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it("rejects 401 when authority status is revoked", async () => {
+    const auth = makeAuthority({ status: "revoked", revoked_at: "2026-05-03T00:00:00Z" });
+    const env = { RRF_KV: makeKV({ [`authority:${AGGREGATOR_RAN}`]: JSON.stringify(auth) }) } as any;
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(makeEnvelope()), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it("rejects 401 when verifyEnvelope returns false", async () => {
+    const auth = makeAuthority();
+    const env = { RRF_KV: makeKV({ [`authority:${AGGREGATOR_RAN}`]: JSON.stringify(auth) }) } as any;
+    __setVerifyEnvelopeForTests(async () => false);
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(makeEnvelope()), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(401);
+  });
+
+  it("stores envelope under both `:latest` and `:<YYYY-MM-DD>` on success", async () => {
+    const auth = makeAuthority();
+    const kv = makeKV({ [`authority:${AGGREGATOR_RAN}`]: JSON.stringify(auth) });
+    const env = { RRF_KV: kv } as any;
+    const verifyFn = vi.fn().mockResolvedValue(true);
+    __setVerifyEnvelopeForTests(verifyFn);
+    const env_ = makeEnvelope({ signed_at: "2026-05-04T14:21:42Z" });
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(env_), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(201);
+    expect(verifyFn).toHaveBeenCalledTimes(1);
+    expect(kv._store.has("compatibility-matrix:latest")).toBe(true);
+    expect(kv._store.has("compatibility-matrix:2026-05-04")).toBe(true);
+    const out = await r.json() as any;
+    expect(out.stored).toBe(true);
+    expect(out.ran).toBe(AGGREGATOR_RAN);
+    expect(out.pq_kid).toBe(AGGREGATOR_PQ_KID);
+    expect(out.date).toBe("2026-05-04");
+  });
+
+  it("accepts envelope with only signature_mldsa65 (Ed25519 optional)", async () => {
+    const auth = makeAuthority();
+    const env = { RRF_KV: makeKV({ [`authority:${AGGREGATOR_RAN}`]: JSON.stringify(auth) }) } as any;
+    __setVerifyEnvelopeForTests(async () => true);
+    const env_ = makeEnvelope({ alg: ["ML-DSA-65"] });
+    delete (env_ as any).kid;
+    delete (env_ as any).signature_ed25519;
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(env_), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(201);
+  });
+});

--- a/functions/v2/compatibility-matrix/index.test.ts
+++ b/functions/v2/compatibility-matrix/index.test.ts
@@ -115,6 +115,21 @@ describe("POST /v2/compatibility-matrix", () => {
     expect(r.status).toBe(400);
   });
 
+  it("rejects 400 when signature_mldsa65 is not valid base64 (would crash atob)", async () => {
+    // Regression: previously isValidEnvelope only checked typeof === "string",
+    // so a malformed base64 made fromB64()/atob() throw DOMException → 500.
+    // Now caught at validation before any verifier runs (no crypto mocks needed).
+    const env = { RRF_KV: makeKV() } as any;
+    const env_ = makeEnvelope({ signature_mldsa65: "!!! not base64 !!!" });
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(env_), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(400);
+    const body = await r.json() as any;
+    expect(body.error.toLowerCase()).toContain("envelope shape invalid");
+  });
+
   it("rejects 400 when signature_ed25519 present but kid missing", async () => {
     // dependentRequired: {signature_ed25519: ["kid"]} — schema-level invariant.
     const env = { RRF_KV: makeKV() } as any;
@@ -125,6 +140,20 @@ describe("POST /v2/compatibility-matrix", () => {
       request: new Request("https://x/", { method: "POST", body: JSON.stringify(env_), headers: { "Content-Type": "application/json" } }),
     } as any);
     expect(r.status).toBe(400);  // schema violation
+  });
+
+  it("returns 500 when authority KV record is malformed JSON", async () => {
+    // Defensive: KV could hold malformed JSON from manual edit or partial write
+    // during migration. Endpoint must return 500 with a generic error, not
+    // crash the worker with an unhandled SyntaxError.
+    const env = { RRF_KV: makeKV({ [`authority:${AGGREGATOR_RAN}`]: "not json{" }) } as any;
+    const r = await onRequestPost({
+      env,
+      request: new Request("https://x/", { method: "POST", body: JSON.stringify(makeEnvelope()), headers: { "Content-Type": "application/json" } }),
+    } as any);
+    expect(r.status).toBe(500);
+    const body = await r.json() as any;
+    expect(body.error.toLowerCase()).toContain("authority record corrupted");
   });
 
   it("rejects 401 when ran does not resolve to a registered authority", async () => {

--- a/functions/v2/compatibility-matrix/index.ts
+++ b/functions/v2/compatibility-matrix/index.ts
@@ -35,8 +35,15 @@ function json(obj: unknown, status = 200): Response {
 
 function fromB64(s: string): Uint8Array {
   // Standard base64 (NOT base64url) per envelope schema contentEncoding.
+  // Caller MUST ensure `s` matches B64_RE (validated up-front in isValidEnvelope)
+  // so atob cannot throw DOMException at this point.
   return Uint8Array.from(atob(s), c => c.charCodeAt(0));
 }
+
+// Standard base64 character set (NOT base64url). Anchored; allows 0-2 trailing '='.
+// Validating up-front in isValidEnvelope means downstream fromB64() / atob() cannot
+// throw DOMException on malformed input — keeps verifier code clean (no try/catch).
+const B64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 
 function isValidEnvelope(x: unknown): x is VersionTupleEnvelope {
   if (!x || typeof x !== "object") return false;
@@ -46,12 +53,12 @@ function isValidEnvelope(x: unknown): x is VersionTupleEnvelope {
   if (e.alg.length === 2 && e.alg[1] !== "Ed25519") return false;
   if (e.alg.length > 2) return false;
   if (typeof e.pq_kid !== "string" || !/^[0-9a-f]{8,}$/.test(e.pq_kid)) return false;
-  if (typeof e.payload !== "string") return false;
-  if (typeof e.signature_mldsa65 !== "string") return false;
+  if (typeof e.payload !== "string" || !B64_RE.test(e.payload)) return false;
+  if (typeof e.signature_mldsa65 !== "string" || !B64_RE.test(e.signature_mldsa65)) return false;
   if (typeof e.signed_at !== "string") return false;
   // dependentRequired: signature_ed25519 → kid
   if (e.signature_ed25519 !== undefined) {
-    if (typeof e.signature_ed25519 !== "string") return false;
+    if (typeof e.signature_ed25519 !== "string" || !B64_RE.test(e.signature_ed25519)) return false;
     if (typeof e.kid !== "string" || !/^[0-9a-f]{8,}$/.test(e.kid)) return false;
   } else if (e.kid !== undefined && (typeof e.kid !== "string" || !/^[0-9a-f]{8,}$/.test(e.kid))) {
     // If kid is present without ed25519, it must still be a valid hex string;
@@ -94,6 +101,11 @@ async function realVerifyEnvelope(
   return true;
 }
 
+// TEST_SEAM: __impl + __setVerifyEnvelopeForTests is intentional test machinery.
+// Cannot use vi.doMock("./index") because onRequestPost lexically captures
+// the verify reference at module load. Do not remove unless tests are migrated
+// to dependency injection (e.g., onRequestPost(deps = {verifyEnvelope: real})).
+//
 // Module-level mutable seam — tests swap this without trying to re-mock the
 // statically imported `onRequestPost` (which would have already captured the
 // original reference via lexical scope).
@@ -139,7 +151,14 @@ export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
   // Direct authority lookup (no scan).
   const raw = await env.RRF_KV.get(`authority:${envelope.ran}`, "text");
   if (!raw) return json({ error: `RAN ${envelope.ran} not found` }, 401);
-  const authority = JSON.parse(raw) as AuthorityRecord;
+  let authority: AuthorityRecord;
+  try {
+    authority = JSON.parse(raw) as AuthorityRecord;
+  } catch {
+    // KV could conceivably hold malformed JSON from manual edits or partial-write
+    // during migration. Return 500 rather than letting the worker crash.
+    return json({ error: "authority record corrupted" }, 500);
+  }
 
   if (authority.status !== "active") {
     return json({ error: `authority ${envelope.ran} status is "${authority.status}"` }, 401);

--- a/functions/v2/compatibility-matrix/index.ts
+++ b/functions/v2/compatibility-matrix/index.ts
@@ -1,0 +1,165 @@
+/**
+ * GET  /v2/compatibility-matrix → returns the latest signed daily matrix envelope from KV.
+ * POST /v2/compatibility-matrix → verifies aggregator hybrid signature, stores in KV.
+ *
+ * Storage model: opencastor-ops cron POSTs after signing; RRF stores in KV. Each successful
+ * push writes both `compatibility-matrix:latest` and `compatibility-matrix:<YYYY-MM-DD>`
+ * (date from envelope.signed_at).
+ *
+ * Auth (POST): signature gate only.
+ *   - envelope.ran must resolve to an active authority via `authority:${ran}` (single KV get).
+ *   - authority.purpose must be "compatibility-matrix-aggregate".
+ *   - authority.status must be "active".
+ *   - envelope.pq_kid must equal authority.pq_kid.
+ *   - signature_mldsa65 MUST verify (verifyMlDsa from rcan-ts).
+ *   - If signature_ed25519 present, it MUST also verify (Web Crypto Ed25519).
+ *
+ * Conforms to rcan-spec /schemas/version-tuple-envelope.json. Per RCAN v3.2 Decision 3
+ * (pqc-hybrid-v1, PQ-required-classical-optional): ML-DSA-65 is required, Ed25519 is
+ * optional but verified when present.
+ */
+
+import type { AuthorityRecord, VersionTupleEnvelope } from "../_lib/types.js";
+import { verifyMlDsa } from "rcan-ts";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+}
+
+const AGGREGATOR_PURPOSE = "compatibility-matrix-aggregate";
+const KV_LATEST = "compatibility-matrix:latest";
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function fromB64(s: string): Uint8Array {
+  // Standard base64 (NOT base64url) per envelope schema contentEncoding.
+  return Uint8Array.from(atob(s), c => c.charCodeAt(0));
+}
+
+function isValidEnvelope(x: unknown): x is VersionTupleEnvelope {
+  if (!x || typeof x !== "object") return false;
+  const e = x as Record<string, unknown>;
+  if (typeof e.ran !== "string" || !/^RAN-\d{12}$/.test(e.ran)) return false;
+  if (!Array.isArray(e.alg) || e.alg.length < 1 || e.alg[0] !== "ML-DSA-65") return false;
+  if (e.alg.length === 2 && e.alg[1] !== "Ed25519") return false;
+  if (e.alg.length > 2) return false;
+  if (typeof e.pq_kid !== "string" || !/^[0-9a-f]{8,}$/.test(e.pq_kid)) return false;
+  if (typeof e.payload !== "string") return false;
+  if (typeof e.signature_mldsa65 !== "string") return false;
+  if (typeof e.signed_at !== "string") return false;
+  // dependentRequired: signature_ed25519 → kid
+  if (e.signature_ed25519 !== undefined) {
+    if (typeof e.signature_ed25519 !== "string") return false;
+    if (typeof e.kid !== "string" || !/^[0-9a-f]{8,}$/.test(e.kid)) return false;
+  } else if (e.kid !== undefined && (typeof e.kid !== "string" || !/^[0-9a-f]{8,}$/.test(e.kid))) {
+    // If kid is present without ed25519, it must still be a valid hex string;
+    // we don't reject — schema allows kid alone — but we validate the type.
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Real signature-verification implementation. Test seam wraps this so that
+ * tests can override without statically imported handlers re-binding the
+ * production function.
+ */
+async function realVerifyEnvelope(
+  envelope: VersionTupleEnvelope,
+  authority: AuthorityRecord,
+): Promise<boolean> {
+  const msg = fromB64(envelope.payload);
+  const pqPub = fromB64(authority.pq_signing_pub);
+  const pqSig = fromB64(envelope.signature_mldsa65);
+
+  // ML-DSA-65 always required.
+  if (!verifyMlDsa(pqPub, msg, pqSig)) return false;
+
+  // Ed25519 conditional.
+  if (envelope.signature_ed25519) {
+    try {
+      const edPub = fromB64(authority.signing_pub);
+      const edSig = fromB64(envelope.signature_ed25519);
+      // Web Crypto Ed25519 (Cloudflare Workers, since 2023; Node 22+).
+      const key = await crypto.subtle.importKey("raw", edPub, { name: "Ed25519" }, false, ["verify"]);
+      const ok = await crypto.subtle.verify({ name: "Ed25519" }, key, edSig, msg);
+      if (!ok) return false;
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+// Module-level mutable seam — tests swap this without trying to re-mock the
+// statically imported `onRequestPost` (which would have already captured the
+// original reference via lexical scope).
+const __impl: {
+  verifyEnvelope: (
+    envelope: VersionTupleEnvelope,
+    authority: AuthorityRecord,
+  ) => Promise<boolean>;
+} = {
+  verifyEnvelope: realVerifyEnvelope,
+};
+
+/** Test-only: replace the verifyEnvelope implementation. */
+export function __setVerifyEnvelopeForTests(
+  fn: (envelope: VersionTupleEnvelope, authority: AuthorityRecord) => Promise<boolean>,
+): void {
+  __impl.verifyEnvelope = fn;
+}
+
+/** Test-only: restore the production verifyEnvelope. */
+export function __resetVerifyEnvelopeForTests(): void {
+  __impl.verifyEnvelope = realVerifyEnvelope;
+}
+
+export const onRequestGet: PagesFunction<Env> = async ({ env }) => {
+  const raw = await env.RRF_KV.get(KV_LATEST, "text");
+  if (!raw) return json({ error: "no matrix available yet — check back after first daily aggregator run" }, 503);
+  return new Response(raw, { status: 200, headers: { "Content-Type": "application/json" } });
+};
+
+export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "invalid JSON" }, 400);
+  }
+  if (!isValidEnvelope(body)) {
+    return json({ error: "envelope shape invalid (see /schemas/version-tuple-envelope.json)" }, 400);
+  }
+  const envelope = body as VersionTupleEnvelope;
+
+  // Direct authority lookup (no scan).
+  const raw = await env.RRF_KV.get(`authority:${envelope.ran}`, "text");
+  if (!raw) return json({ error: `RAN ${envelope.ran} not found` }, 401);
+  const authority = JSON.parse(raw) as AuthorityRecord;
+
+  if (authority.status !== "active") {
+    return json({ error: `authority ${envelope.ran} status is "${authority.status}"` }, 401);
+  }
+  if (authority.purpose !== AGGREGATOR_PURPOSE) {
+    return json({ error: `authority purpose is "${authority.purpose}", not "${AGGREGATOR_PURPOSE}"` }, 401);
+  }
+  if (envelope.pq_kid !== authority.pq_kid) {
+    return json({ error: "pq_kid does not match registered authority" }, 401);
+  }
+
+  // Signature verification (via the test-overridable seam).
+  const verified = await __impl.verifyEnvelope(envelope, authority);
+  if (!verified) return json({ error: "envelope signature verification failed" }, 401);
+
+  // Storage: latest + dated.
+  const date = envelope.signed_at.slice(0, 10);
+  const stored = JSON.stringify(envelope);
+  await env.RRF_KV.put(KV_LATEST, stored);
+  await env.RRF_KV.put(`compatibility-matrix:${date}`, stored, { expirationTtl: 365 * 24 * 3600 });
+
+  return json({ stored: true, ran: envelope.ran, pq_kid: envelope.pq_kid, date }, 201);
+};


### PR DESCRIPTION
## Summary

- New Cloudflare Pages Function at `functions/v2/compatibility-matrix/` exposing `GET` (read latest signed daily matrix from KV) + `POST` (verify aggregator hybrid signature, store in KV).
- Conforms to canonical `version-tuple-envelope.json` schema in rcan-spec — direct `authority:${envelope.ran}` lookup (no scan), `verifyMlDsa` for required PQ + Web Crypto Ed25519 conditional, storage routing via `envelope.signed_at[:10]`.
- Per RCAN v3.2 Decision 3 (`pqc-hybrid-v1`): ML-DSA-65 always required; Ed25519 optional but must verify if present. Verification policy split because `verifyHybrid` cannot model the optional-classical case.

## What this enables

This is the authoritative read endpoint for the OpenCastor compatibility matrix. The opencastor-ops cron (already shipped on `craigm26/opencastor-ops` master) signs the daily aggregate with the aggregator hybrid keypair (RAN-000000000001, registered via Plan 1 Task 2) and POSTs the envelope here. Downstream consumers (rcan.dev `/compatibility` page in Plan 1 Task 17, opencastor-ops `monitor.repo_registry`) read from `/v2/compatibility-matrix` to render live matrix state.

## Test plan

- [x] 14 Vitest tests pass in `functions/v2/compatibility-matrix/index.test.ts`
- [x] Full RRF suite (233 tests) green
- [x] Schema conformance verified line-by-line vs `~/rcan-spec/schemas/version-tuple-envelope.json`
- [x] Spec compliance review ✅
- [x] Code quality review ✅ (4 Important + 6 Minor flagged; 3 Important + 1 Minor applied as fix-up commit `f77cd04`)
- [ ] Manual E2E from this machine (Plan 1 Task 16 Subtask 16c) — **operator-only post-merge**: `python -m monitor.push_matrix && curl /v2/compatibility-matrix`

## Defensive hardening (review fix-up commit `f77cd04`)

- `isValidEnvelope` now validates base64 charset on `payload` / `signature_mldsa65` / `signature_ed25519` (regex `/^[A-Za-z0-9+/]+={0,2}$/`) — prevents `atob` from throwing `DOMException` and crashing the worker (would have been 500; now 400).
- `JSON.parse` of the authority KV record wrapped in try/catch — returns 500 "authority record corrupted" instead of leaking stack trace.
- Test seam (`__impl.verifyEnvelope` mutable dispatcher + `__setVerifyEnvelopeForTests` / `__resetVerifyEnvelopeForTests`) documented with a `// TEST_SEAM:` comment so future maintainers don't accidentally rip it out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)