### PR TITLE
site: Plan 2 Phase 3 — retire hardcoded RCAN versions on RRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 The open registry for RCAN-compliant robots — assigns permanent global identities to robots the way ICANN assigns domain names.
 
-[![Spec](https://img.shields.io/badge/RCAN-v3.0-blue)](https://rcan.dev/spec/)
+[![Spec](https://img.shields.io/badge/RCAN-live%20matrix-blue)](https://rcan.dev/compatibility)
 [![License](https://img.shields.io/badge/license-CC%20BY%204.0-green)](https://creativecommons.org/licenses/by/4.0/)
 
 🌐 **[robotregistryfoundation.org](https://robotregistryfoundation.org)**
+
+<!-- BEGIN: ecosystem regulatory disclaimer (canonical, derived from spec §10) -->
+> **Compliance evidence is not regulatory sufficiency.**
+>
+> Compliance packet generation and RRF submission produce *evidence*; they do not constitute regulatory sufficiency in any jurisdiction. Per-jurisdiction conformity assessments and notified-body engagement are the user's responsibility, in consultation with qualified counsel.
+<!-- END: ecosystem regulatory disclaimer -->
 
 ## What RRF Does
 

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -135,7 +135,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
             the registry and RRN system now governed by this Foundation.
           </p>
           <ul class="text-sm text-text-muted space-y-1">
-            <li>• Full RCAN v2.2 conformance (L1–L5) · RRN/RCN/RMN/RHN entity registration</li>
+            <li>• Full <a href="https://rcan.dev/compatibility" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">RCAN protocol</a> conformance (L1–L5) · RRN/RCN/RMN/RHN entity registration</li>
             <li>• Robot Registration Number (RRN) minting and validation</li>
             <li>• Tiered AI brain with provider fallback</li>
             <li>• Fleet management, telemetry, and federated swarms</li>

--- a/src/pages/api/index.astro
+++ b/src/pages/api/index.astro
@@ -1,7 +1,31 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
-// v2 entity endpoints — RCAN v2.2 §21
+// SSR-fetch the live compatibility matrix at build time so we don't hardcode
+// a spec version on this marketing surface (per spec §8). Falls back to a
+// neutral label if the registry is unreachable or returns an unexpected shape.
+let rcanVersionLabel = 'live compatibility matrix';
+try {
+  const response = await fetch('https://robotregistryfoundation.org/v2/compatibility-matrix', {
+    headers: { 'Accept': 'application/json' },
+  });
+  if (response.ok) {
+    const envelope = await response.json();
+    if (envelope?.payload) {
+      const decoded = JSON.parse(
+        Buffer.from(envelope.payload, 'base64url').toString('utf-8')
+      );
+      const version = decoded?.projects?.['rcan-spec']?.fields?.protocol_version?.value;
+      if (version) {
+        rcanVersionLabel = `RCAN ${version}`;
+      }
+    }
+  }
+} catch {
+  // network or shape errors are non-fatal; ship the neutral label
+}
+
+// v2 entity endpoints — RCAN protocol §21
 const entityEndpoints = [
   // ── Robots (RRN) ──────────────────────────────────────────────────────────
   {
@@ -17,7 +41,7 @@ const entityEndpoints = [
           { name: "manufacturer",     type: "string",  required: true,  desc: "Manufacturer or team name" },
           { name: "model",            type: "string",  required: true,  desc: "Model/product identifier" },
           { name: "firmware_version", type: "string",  required: true,  desc: "Installed firmware version string" },
-          { name: "rcan_version",     type: "string",  required: true,  desc: "RCAN spec version (must be \"2.2\")" },
+          { name: "rcan_version",     type: "string",  required: true,  desc: "RCAN protocol version string from the registering payload — see rcan.dev/compatibility for the current accepted value" },
           { name: "pq_signing_pub",   type: "string",  required: false, desc: "ML-DSA-65 public key (base64-encoded, NIST FIPS 204)" },
           { name: "pq_kid",           type: "string",  required: false, desc: "Key ID — 8-char hex (sha256 of pub key prefix)" },
           { name: "ruri",             type: "string",  required: false, desc: "RCAN Robot URI: rcan://{domain}/{org}/{model}/{unit}" },
@@ -170,7 +194,7 @@ const entityEndpoints = [
           { name: "name",              type: "string",  required: true,  desc: "Harness name" },
           { name: "version",           type: "string",  required: true,  desc: "Semantic version string" },
           { name: "harness_type",      type: "string",  required: true,  desc: "vla | llm_planner | multimodal | hybrid | specialist | safety_monitor | orchestrator | other" },
-          { name: "rcan_version",      type: "string",  required: true,  desc: "Minimum RCAN version required (must be \"2.2\")" },
+          { name: "rcan_version",      type: "string",  required: true,  desc: "Minimum RCAN protocol version required — see rcan.dev/compatibility for the current accepted value" },
           { name: "description",       type: "string",  required: false, desc: "Human-readable description" },
           { name: "model_ids",         type: "array",   required: false, desc: "RMN[] — models used by this harness" },
           { name: "compatible_robots", type: "array",   required: false, desc: "RRN[] — target robots (empty = universal)" },
@@ -246,7 +270,7 @@ const methodColors: Record<string, string> = {
 
 <BaseLayout
   title="API Reference"
-  description="Robot Registry Foundation REST API v2 — register and query robots (RRN), components (RCN), AI models (RMN), and harnesses (RHN). RCAN v2.2 §21 entity numbering."
+  description="Robot Registry Foundation REST API v2 — register and query robots (RRN), components (RCN), AI models (RMN), and harnesses (RHN). RCAN protocol §21 entity numbering."
 >
 
   <div class="pt-8">
@@ -261,12 +285,12 @@ const methodColors: Record<string, string> = {
     <div class="mb-10 pb-8 border-b border-border">
       <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-border bg-bg-card text-xs font-mono text-text-muted mb-5">
         <span class="w-1.5 h-1.5 rounded-full bg-accent"></span>
-        v2 · RCAN v2.2 §21
+        v2 · {rcanVersionLabel} · §21
       </div>
       <h1 class="font-display text-3xl md:text-4xl font-semibold text-text mb-3">API Reference</h1>
       <p class="text-text-muted max-w-2xl">
         Programmatic access to register and query all four RCAN entity types.
-        The v2 API is the only supported API — v1 was removed as of RCAN v2.0.
+        The v2 API is the only supported API — v1 was removed when earlier RCAN protocol versions were retired.
       </p>
 
       <!-- Quick info grid -->
@@ -307,7 +331,7 @@ const methodColors: Record<string, string> = {
 
     <!-- Entity type legend -->
     <div class="mb-10">
-      <h2 class="font-display text-lg font-semibold text-text mb-4">Entity Types — RCAN v2.2 §21.2.2</h2>
+      <h2 class="font-display text-lg font-semibold text-text mb-4">Entity Types — <a href="https://rcan.dev/spec/section-21/" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">RCAN protocol §21.2.2</a></h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-3">
         {[
           { prefix: "RRN", label: "Robot Registration Number", desc: "Whole robots — the primary unit of identity", color: "text-accent border-accent/30 bg-primary/10" },

--- a/src/pages/api/registry-tiers.astro
+++ b/src/pages/api/registry-tiers.astro
@@ -1,8 +1,9 @@
 ---
 /**
- * Registry Tier API Specification — RCAN v2.2
+ * Registry Tier API Specification — RCAN protocol §21
  *
- * Documents the registry federation endpoints introduced in RCAN v2.2 (GAP-14).
+ * Documents the registry federation endpoints (GAP-14). For protocol versions
+ * see https://rcan.dev/compatibility (live matrix).
  *
  * Registry Tiers:
  *   root          — The authoritative root registry (registry.opencastor.com).
@@ -172,14 +173,14 @@ const endpoints = [
 ---
 
 <BaseLayout
-  title="Registry Tier API — RCAN v2.2"
-  description="Federation API for RCAN v2.2 registry tiers, trust anchors, and cross-registry verification (GAP-14)"
+  title="Registry Tier API — RCAN protocol §21"
+  description="Federation API for the RCAN protocol registry tiers, trust anchors, and cross-registry verification (GAP-14). See rcan.dev/compatibility for protocol versions."
 >
   <main class="max-w-4xl mx-auto px-4 py-12">
     <div class="mb-10">
-      <h1 class="text-3xl font-bold mb-3">Registry Tier API <span class="text-sm font-normal text-gray-500 ml-2">RCAN v2.2</span></h1>
+      <h1 class="text-3xl font-bold mb-3">Registry Tier API <span class="text-sm font-normal text-gray-500 ml-2"><a href="https://rcan.dev/compatibility" target="_blank" rel="noopener noreferrer" class="hover:underline">live matrix</a></span></h1>
       <p class="text-gray-600 mb-4">
-        Federation endpoints for RCAN v2.2 registry trust hierarchy (GAP-14).
+        Federation endpoints for the RCAN protocol registry trust hierarchy (GAP-14).
         Enables cross-registry command validation via signed trust anchors.
       </p>
 
@@ -193,9 +194,9 @@ const endpoints = [
       </div>
 
       <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
-        <h2 class="font-semibold text-yellow-800 mb-2">Status: Specification (v2.2)</h2>
+        <h2 class="font-semibold text-yellow-800 mb-2">Status: Specification</h2>
         <p class="text-sm text-yellow-700">
-          These endpoints are specified for RCAN v2.2 The root registry endpoint
+          These endpoints are specified by the <a href="https://rcan.dev/spec/section-21/" target="_blank" rel="noopener noreferrer" class="hover:underline">RCAN protocol §21</a>. The root registry endpoint
           (<code>POST /api/v1/registries/{'{domain}'}/verify</code>) is only active on
           <code>registry.opencastor.com</code>. Community RRF instances expose GET-only
           trust anchor lookups.

--- a/src/pages/api/revocation.astro
+++ b/src/pages/api/revocation.astro
@@ -2,8 +2,9 @@
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
 // ---------------------------------------------------------------------------
-// RCAN v2.2 — Robot Identity Revocation + Key Management API
+// RCAN protocol — Robot Identity Revocation + Key Management API
 // Spec reference: GAP-02 (§13 Robot Identity Revocation), GAP-09 (§8.6 Key Lifecycle)
+// For protocol versions see https://rcan.dev/compatibility (live matrix).
 // ---------------------------------------------------------------------------
 
 const revocationEndpoints = [
@@ -125,7 +126,7 @@ const methodColors: Record<string, string> = {
 
 <BaseLayout
   title="Revocation & Key API"
-  description="RCAN v2.2 Robot Identity Revocation and Key Management API — revocation status, revoke endpoint, public key JWKS."
+  description="RCAN protocol Robot Identity Revocation and Key Management API — revocation status, revoke endpoint, public key JWKS. See rcan.dev/compatibility for protocol versions."
 >
 
   <div class="pt-8">
@@ -143,21 +144,21 @@ const methodColors: Record<string, string> = {
       <div class="mb-10">
         <div class="flex items-center gap-3 mb-3">
           <h1 class="font-display text-4xl md:text-5xl font-semibold text-text">Revocation & Key API</h1>
-          <span class="px-2.5 py-1 rounded-full text-xs font-mono font-bold bg-violet-500/10 text-violet-400 border border-violet-500/30 flex-shrink-0">
-            RCAN v2.2
-          </span>
+          <a href="https://rcan.dev/compatibility" target="_blank" rel="noopener noreferrer" class="px-2.5 py-1 rounded-full text-xs font-mono font-bold bg-violet-500/10 text-violet-400 border border-violet-500/30 flex-shrink-0 hover:bg-violet-500/20 transition-colors">
+            RCAN protocol
+          </a>
         </div>
         <p class="text-lg text-text-muted leading-relaxed">
           Robot identity revocation and public key management endpoints.
           Defined by <strong class="text-text">GAP-02</strong> (Robot Identity Revocation, §13)
-          and <strong class="text-text">GAP-09</strong> (Key Lifecycle, §8.6) of the RCAN v2.2 spec.
+          and <strong class="text-text">GAP-09</strong> (Key Lifecycle, §8.6) of the RCAN protocol.
         </p>
       </div>
 
       <!-- Spec summary card -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-12">
         {[
-          { label: 'Spec', value: 'RCAN v2.2 §13 + §8.6' },
+          { label: 'Spec', value: 'RCAN protocol §13 + §8.6' },
           { label: 'MessageType 19', value: 'ROBOT_REVOCATION broadcast' },
           { label: 'Cache TTL', value: '1h (active), 5m (revoked)' },
         ].map(item => (
@@ -192,9 +193,6 @@ const methodColors: Record<string, string> = {
                 {endpoint.method}
               </span>
               <code class="text-sm font-mono text-text flex-1">{endpoint.path}</code>
-              <span class="text-xs font-mono px-2 py-0.5 rounded bg-violet-500/10 text-violet-400 border border-violet-500/20 flex-shrink-0">
-                v2.2
-              </span>
             </div>
 
             <div class="p-5 space-y-5">
@@ -258,7 +256,7 @@ const methodColors: Record<string, string> = {
         </h3>
         <p class="text-sm text-text-muted leading-relaxed mb-3">
           When a robot is revoked via <code class="text-accent">POST /api/v1/robots/:rrn/revoke</code>, the registry
-          broadcasts a <code class="text-accent">ROBOT_REVOCATION</code> message (MessageType 19, RCAN v2.2 §13.4)
+          broadcasts a <code class="text-accent">ROBOT_REVOCATION</code> message (MessageType 19, RCAN protocol §13.4)
           to all registered peers. Receiving robots <strong class="text-text">MUST</strong>:
         </p>
         <ul class="text-sm text-text-muted space-y-1 list-disc list-inside ml-2">

--- a/src/pages/rcan-integration/index.astro
+++ b/src/pages/rcan-integration/index.astro
@@ -14,7 +14,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       <div>
         <div class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-border bg-bg-card text-xs font-mono text-text-muted mb-8">
           <span class="w-1.5 h-1.5 rounded-full bg-accent"></span>
-          RCAN v2.2 · <a href="https://rcan.dev/spec/section-21/" target="_blank" rel="noopener noreferrer" class="hover:text-accent transition-colors">§21</a> Stable
+          <a href="https://rcan.dev/spec/section-21/" target="_blank" rel="noopener noreferrer" class="hover:text-accent transition-colors">RCAN protocol §21</a> · Stable
         </div>
         <h1 class="font-display text-4xl md:text-5xl font-semibold text-text leading-tight tracking-tight mb-5">
           How the RRF and RCAN<br class="hidden md:block" /> Work Together
@@ -94,10 +94,10 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
             <li class="flex gap-2"><span class="text-accent mt-0.5">→</span> Any language or runtime</li>
             <li class="flex gap-2"><span class="text-accent mt-0.5">→</span> ML-DSA-65 message signing (NIST FIPS 204)</li>
             <li class="flex gap-2"><span class="text-accent mt-0.5">→</span> Hierarchical URIs (RURIs)</li>
-            <li class="flex gap-2"><span class="text-accent mt-0.5">→</span> Current spec: <span class="font-mono text-xs">v2.2</span> · 4 entity types (RRN/RCN/RMN/RHN)</li>
+            <li class="flex gap-2"><span class="text-accent mt-0.5">→</span> See the <a href="https://rcan.dev/compatibility" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">live compatibility matrix</a> · 4 entity types (RRN/RCN/RMN/RHN)</li>
           </ul>
           <div class="mt-4 pt-4 border-t border-border/60">
-            <p class="text-xs text-text-faint font-mono uppercase tracking-widest mb-2">v2.2 registry-relevant features</p>
+            <p class="text-xs text-text-faint font-mono uppercase tracking-widest mb-2">Registry-relevant features</p>
             <ul class="space-y-1 text-xs text-text-muted">
               <li class="flex gap-2"><span class="text-accent/70">→</span> Federated consent protocol (FEDERATION_SYNC, cross-registry JWT trust)</li>
               <li class="flex gap-2"><span class="text-accent/70">→</span> Human identity LoA 1/2/3 (FIDO2, <code class="font-mono text-[10px]">min_loa_for_control</code>)</li>
@@ -361,7 +361,7 @@ rcan_robot_uptime_ms{ruri="rcan://robot.local"} 3600000`}</pre>
           <div class="font-mono text-xs text-accent uppercase tracking-widest mb-2">RCAN Reference Implementation</div>
           <h3 class="font-display text-xl font-semibold text-text mb-2">OpenCastor</h3>
           <p class="text-sm text-text-muted leading-relaxed">
-            Full RCAN v2.2 conformance · ML-DSA-65 PQ signing · RBAC + capability leases · Virtual FS with safety kernel · 4-type registry (RRN/RCN/RMN/RHN) · RRF <a href="https://rcan.dev/spec/section-21/" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">§21</a> registry integration · Runs on Raspberry Pi, x86, and more.
+            Full <a href="https://rcan.dev/compatibility" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">RCAN protocol</a> conformance · ML-DSA-65 PQ signing · RBAC + capability leases · Virtual FS with safety kernel · 4-type registry (RRN/RCN/RMN/RHN) · RRF <a href="https://rcan.dev/spec/section-21/" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">§21</a> registry integration · Runs on Raspberry Pi, x86, and more.
           </p>
         </div>
         <div class="flex flex-col gap-3 flex-shrink-0">

--- a/src/pages/registry/[rrn].astro
+++ b/src/pages/registry/[rrn].astro
@@ -129,7 +129,7 @@ const dataUri = `data:application/json;charset=utf-8,${encodeURIComponent(record
       </div>
     </div>
 
-    <!-- RCAN v1.5 Status (shown only when v1.5 fields are present) -->
+    <!-- RCAN protocol status (shown only when protocol fields are present) -->
     {(robot.rcan_version || robot.revocation_status || robot.supports_qos_2 !== undefined) && (
       <div class="bg-bg-card border border-border rounded-xl p-6 mb-6">
         <div class="flex items-center gap-2 mb-4">
@@ -190,7 +190,7 @@ const dataUri = `data:application/json;charset=utf-8,${encodeURIComponent(record
                 </span>
               )}
               {!robot.supports_qos_2 && !robot.supports_delegation && !robot.offline_capable && (
-                <span class="text-xs text-text-faint font-mono">{robot.rcan_version ? `v${robot.rcan_version}` : 'v1.6'}</span>
+                <span class="text-xs text-text-faint font-mono">{robot.rcan_version ? `v${robot.rcan_version}` : '—'}</span>
               )}
             </dd>
           </div>


### PR DESCRIPTION
## Summary

Phase 3 PR 2 of [Plan 2 (Documentation Accuracy)](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/plans/2026-05-04-documentation-accuracy.md). After Phase 3 PR 1 (opencastor-ops `dacde18`) allowlisted RRF's deploy/firestore-* migration runbooks (dropping the lint count from 30 -> 24), this PR fixes all 24 remaining marketing-surface hits.

### What changed

- **README.md**: `RCAN-v3.0` badge -> `RCAN-live%20matrix` linking to `/compatibility`. Embedded regulatory disclaimer (canonical, from spec §10).
- **`src/pages/api/index.astro`**: SSR-fetches the live compatibility matrix at build time and renders the dynamic `RCAN <version>` label in the page header. Falls back to neutral 'live compatibility matrix' label on failure. 4 inline body mentions -> plain `RCAN protocol` text.
- **`src/pages/api/registry-tiers.astro`** (7 hits), **`revocation.astro`** (6 hits): matrix-link or non-versioned framing.
- **`src/pages/rcan-integration/index.astro`** (3 hits): badge versioning dropped; "Current spec" framing replaced with matrix link.
- **`src/pages/about/index.astro`** + **`src/pages/registry/[rrn].astro`**: single-hit cleanup.

### GitHub About

Set to: `Robot Registry Foundation — neutral registry of RRN/RCN/RMN/RHN identities, public keys, and conformance evidence. Identity, not regulation. See rcan.dev/compatibility for protocol versions.`

### Verification

- [x] `forbidden-phrase-lint` 0 hits across whole repo (was 24 before this PR).
- [x] `npm run build` clean (12 pages, 5.6s).
- [x] `vitest run` 235/235 passing.
- [x] api/index.astro renders the live RCAN protocol version (`RCAN 3.2.1`) from the matrix endpoint.

### Sequencing

- Phase 3 PR 1 (closed): opencastor-ops `dacde18` — dict allowlist for RRF deploy/firestore migration runbooks.
- Phase 3 PR 2 (this): wording fixes.
- Phase 3 PR 3 (next): wire `.github/workflows/forbidden-phrase-lint.yml` + provision `OPENCASTOR_OPS_READ_TOKEN` PAT.

## Test plan

- [ ] Cloudflare Pages preview renders the api/index.astro page with the live RCAN version label
- [ ] Regulatory disclaimer renders correctly in README markdown preview
- [ ] No regression on existing pages
- [ ] Spot-check that "RCAN protocol" and matrix links resolve to the right targets

## Refs

- Spec §8 (no hardcoded versions on marketing surfaces)
- §10 (regulatory disclaimer canonical text)
- §3 (RRF identity-only charter, NOT a regulator)
- Phase 2.5 close: rcan-spec `23663ba` (PR #205 + #206)

🤖 Generated with [Claude Code](https://claude.com/claude-code)