### PR TITLE
ci: Plan 2 Phase 3 — wire forbidden-phrase-lint workflow

### DIFF
--- a/.github/workflows/forbidden-phrase-lint.yml
+++ b/.github/workflows/forbidden-phrase-lint.yml
@@ -1,0 +1,48 @@
+name: forbidden-phrase-lint
+
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'src/**'
+      - 'deploy/**'
+      - '.github/workflows/forbidden-phrase-lint.yml'
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Fetch lint + dictionary from opencastor-ops
+        env:
+          AUTH_TOKEN: ${{ secrets.OPENCASTOR_OPS_READ_TOKEN }}
+        run: |
+          set -euo pipefail
+          API="https://api.github.com/repos/craigm26/opencastor-ops/contents"
+          REF="master"
+          mkdir -p .forbidden-phrase-lint
+          curl -fsSL \
+            -H "Authorization: Bearer ${AUTH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "${API}/tools/lint_forbidden_phrases.py?ref=${REF}" \
+            -o .forbidden-phrase-lint/lint.py
+          curl -fsSL \
+            -H "Authorization: Bearer ${AUTH_TOKEN}" \
+            -H "Accept: application/vnd.github.raw" \
+            "${API}/docs/standards/forbidden-phrases.json?ref=${REF}" \
+            -o .forbidden-phrase-lint/dict.json
+      - name: Run lint
+        run: |
+          set -euo pipefail
+          python .forbidden-phrase-lint/lint.py \
+            --dict .forbidden-phrase-lint/dict.json \
+            --root .


### PR DESCRIPTION
## Summary

Phase 3 PR 3 of [Plan 2 (Documentation Accuracy)](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/plans/2026-05-04-documentation-accuracy.md). Adds the canonical forbidden-phrase-lint CI workflow to RRF, locking in the wording-fix work from Phase 3 PR 2 (PR #80).

After this PR merges, Phase 3 closes. Phase 4 (OpenCastor) is unblocked next.

### What changed

- New file: `.github/workflows/forbidden-phrase-lint.yml` (inline-form template, third consumer repo to ship this — robot-md, rcan-spec, now RRF).
- Triggers on PR + push to main.
- Path filters: `README.md`, `CHANGELOG.md`, `src/**`, `deploy/**`, the workflow file itself.

### How it works

1. Workflow checks out RRF.
2. Sets up Python 3.12.
3. Fetches `tools/lint_forbidden_phrases.py` + `docs/standards/forbidden-phrases.json` from `craigm26/opencastor-ops` via authenticated GitHub Contents API requests using the `OPENCASTOR_OPS_READ_TOKEN` secret.
4. Runs the lint against the repo. Exits 1 if any forbidden phrase is found.

The `OPENCASTOR_OPS_READ_TOKEN` secret was provisioned on `craigm26/RobotRegistryFoundation` immediately before this PR.

### Verification

The first CI run on this PR is the live verification — if the workflow runs successfully and exits 0 (no forbidden phrases on the current main), the wiring is correct.

### Sequencing

- Phase 3 PR 1 (closed): opencastor-ops `dacde18` — dict allowlist for RRF firestore migration runbooks (drops 30→24 false positives).
- Phase 3 PR 2 (closed): RRF `0738dbe` (PR #80) — fixed the 24 marketing-surface hits + 3 review-feedback defects.
- Phase 3 PR 3 (this): wire CI workflow + provision PAT.

After merge: Phase 4 (OpenCastor README + docs/ + GitHub About) starts.

## Refs

- Canonical templates: [robot-md/.github/workflows/forbidden-phrase-lint.yml](https://github.com/RobotRegistryFoundation/robot-md/blob/main/.github/workflows/forbidden-phrase-lint.yml), [rcan-spec/.github/workflows/forbidden-phrase-lint.yml](https://github.com/continuonai/rcan-spec/blob/master/.github/workflows/forbidden-phrase-lint.yml)
- Phase 3 PR 1: opencastor-ops `dacde18`
- Phase 3 PR 2: RRF `0738dbe` (PR #80)