### PR TITLE
feat(v2): R1/R2/R3/R7 registry endpoints (Plan 6 Phase 0 Task 5)

### DIFF
--- a/functions/v2/crypto-profiles.ts
+++ b/functions/v2/crypto-profiles.ts
@@ -1,0 +1,30 @@
+/**
+ * GET /v2/crypto-profiles  (R3)
+ * Plan 6 Task 5 — RCAN crypto-profile registry.
+ *
+ * Surfaces the named crypto profiles the protocol supports. Sourced from
+ * rcan-spec §8 (crypto-profile decision).
+ */
+
+const CRYPTO_PROFILES = [
+  { name: "ed25519", alg: "Ed25519", status: "current", since_version: "3.0.0" },
+  { name: "ml-dsa-65-hybrid", alg: "ML-DSA-65 + Ed25519 (hybrid)", status: "future", since_version: "4.0.0" },
+];
+
+export const onRequest: PagesFunction = async ({ request }) => {
+  if (request.method !== "GET") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405, headers: { "Content-Type": "application/json" },
+    });
+  }
+  const body = {
+    matrix_version: "1.0",
+    profiles: CRYPTO_PROFILES,
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+};

--- a/functions/v2/message-types.ts
+++ b/functions/v2/message-types.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /v2/message-types  (R2)
+ * Plan 6 Task 5 — RCAN message-type registry.
+ *
+ * Lists every RCAN message type with its first-supported protocol version
+ * and human-readable purpose. Sourced from rcan-spec authoritative tables.
+ */
+
+const MESSAGE_TYPES = [
+  { name: "INVOKE", since_version: "3.0.0", purpose: "Request a tool invocation against a robot." },
+  { name: "TELEMETRY", since_version: "3.0.0", purpose: "Stream a telemetry sample." },
+  { name: "STATUS", since_version: "3.0.0", purpose: "Report a robot's current state." },
+  { name: "ESTOP", since_version: "3.0.0", purpose: "Trigger a hardware emergency stop." },
+  { name: "AUTHORIZE", since_version: "3.1.0", purpose: "HiTL authorization signal." },
+  { name: "PENDANT_HEARTBEAT", since_version: "3.2.0", purpose: "Pendant peripheral heartbeat." },
+];
+
+export const onRequest: PagesFunction = async ({ request }) => {
+  if (request.method !== "GET") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405, headers: { "Content-Type": "application/json" },
+    });
+  }
+  const body = {
+    matrix_version: "1.0",
+    message_types: MESSAGE_TYPES,
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+};

--- a/functions/v2/p66-schemas.ts
+++ b/functions/v2/p66-schemas.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /v2/p66-schemas  (R7)
+ * Plan 6 Task 5 — Protocol-66 schema registry.
+ *
+ * Surfaces the named JSON schemas used for Protocol-66 packets (the safety
+ * benchmark / FRIA / IFU artifacts in RCAN §22-26). Sourced from rcan-spec.
+ */
+
+const P66_SCHEMAS = [
+  { id: "p66-core", version: "1.0", title: "Protocol-66 core invariants schema." },
+  { id: "safety-benchmark", version: "1.0", title: "Safety-benchmark packet schema (RCAN §23)." },
+  { id: "fria", version: "1.0", title: "Fundamental Rights Impact Assessment packet schema (RCAN §22)." },
+  { id: "ifu", version: "1.0", title: "Instructions-for-Use packet schema (RCAN §24)." },
+];
+
+export const onRequest: PagesFunction = async ({ request }) => {
+  if (request.method !== "GET") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405, headers: { "Content-Type": "application/json" },
+    });
+  }
+  const body = {
+    matrix_version: "1.0",
+    schemas: P66_SCHEMAS,
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+};

--- a/functions/v2/registry-endpoints.test.ts
+++ b/functions/v2/registry-endpoints.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for Plan 6 Task 5 — R1/R2/R3/R7 registry endpoints.
+ */
+
+import { describe, it, expect } from "vitest";
+import { onRequest as onVersions } from "./versions.js";
+import { onRequest as onMessageTypes } from "./message-types.js";
+import { onRequest as onCryptoProfiles } from "./crypto-profiles.js";
+import { onRequest as onP66Schemas } from "./p66-schemas.js";
+
+function makeReq(method: string = "GET"): Parameters<PagesFunction>[0] {
+  return {
+    request: new Request("https://robotregistryfoundation.org/v2/versions", { method }),
+  } as unknown as Parameters<PagesFunction>[0];
+}
+
+describe("R1 /v2/versions", () => {
+  it("returns matrix_version + protocol_versions[]", async () => {
+    const r = await onVersions(makeReq());
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.matrix_version).toBeDefined();
+    expect(Array.isArray(body.protocol_versions)).toBe(true);
+    expect(body.protocol_versions.length).toBeGreaterThan(0);
+    expect(body.protocol_versions[0]).toHaveProperty("version");
+  });
+
+  it("405s on POST", async () => {
+    const r = await onVersions(makeReq("POST"));
+    expect(r.status).toBe(405);
+  });
+});
+
+describe("R2 /v2/message-types", () => {
+  it("returns message_types with name + since_version", async () => {
+    const r = await onMessageTypes(makeReq());
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(Array.isArray(body.message_types)).toBe(true);
+    for (const m of body.message_types) {
+      expect(m).toHaveProperty("name");
+      expect(m).toHaveProperty("since_version");
+    }
+  });
+});
+
+describe("R3 /v2/crypto-profiles", () => {
+  it("returns profiles including ed25519", async () => {
+    const r = await onCryptoProfiles(makeReq());
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(Array.isArray(body.profiles)).toBe(true);
+    expect(body.profiles.some((p: { name: string }) => p.name === "ed25519")).toBe(true);
+  });
+});
+
+describe("R7 /v2/p66-schemas", () => {
+  it("returns named JSON schemas", async () => {
+    const r = await onP66Schemas(makeReq());
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(Array.isArray(body.schemas)).toBe(true);
+    expect(body.schemas.length).toBeGreaterThan(0);
+    expect(body.schemas[0]).toHaveProperty("id");
+  });
+});

--- a/functions/v2/versions.ts
+++ b/functions/v2/versions.ts
@@ -1,0 +1,30 @@
+/**
+ * GET /v2/versions  (R1)
+ * Plan 6 Task 5 — protocol-version registry.
+ *
+ * Surfaces the protocol versions known to RCAN. Static data sourced from
+ * rcan-spec authoritative tables; RRF mirrors on next deploy.
+ */
+
+const PROTOCOL_VERSIONS = [
+  { version: "3.2.0", status: "stable", released_at: "2026-04-24" },
+  { version: "3.2.2", status: "stable", released_at: "2026-05-03" },
+];
+
+export const onRequest: PagesFunction = async ({ request }) => {
+  if (request.method !== "GET") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405, headers: { "Content-Type": "application/json" },
+    });
+  }
+  const body = {
+    matrix_version: "1.0",
+    protocol_versions: PROTOCOL_VERSIONS,
+  };
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+};


### PR DESCRIPTION
Plan 6 cert-tracks Phase 0 Task 5. Adds four read-only registry endpoints under `/v2/` for verifiers to resolve protocol metadata: versions, message-types, crypto-profiles, p66-schemas.

Static data sourced from rcan-spec authoritative tables; refresh on next deploy.

Used `/v2/` (existing convention) instead of plan body's `/api/v2/` (Plan 2 lessons-learned §B URL correction).

5 vitest tests pass. Refs spec §9 Week 4.