### PR TITLE
feat(api): /v2/compliance-bundle intake (Plan 4 Phase 3)

### DIFF
--- a/functions/v2/_lib/aggregator-scope.test.ts
+++ b/functions/v2/_lib/aggregator-scope.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { assertAggregatorScopedFor } from "./aggregator-scope.js";
+import type { AggregatorScope } from "./types.js";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(), list: vi.fn(), delete: vi.fn(),
+    } as unknown as KVNamespace,
+  };
+}
+
+describe("assertAggregatorScopedFor", () => {
+  it("returns ok when scope mapping exists and is not expired", async () => {
+    const scope: AggregatorScope = {
+      ran: "RAN-000000000001",
+      rrn: "RRN-000000000002",
+      authorized_at: "2026-05-04T00:00:00Z",
+      authorized_by: "RAN-000000000001",
+    };
+    const env = makeEnv({
+      "aggregator-scope:RAN-000000000001/RRN-000000000002": JSON.stringify(scope),
+    });
+    const r = await assertAggregatorScopedFor(env, "RAN-000000000001", "RRN-000000000002");
+    expect(r.ok).toBe(true);
+  });
+
+  it("returns 403 when no scope mapping exists", async () => {
+    const env = makeEnv();
+    const r = await assertAggregatorScopedFor(env, "RAN-000000000001", "RRN-000000000999");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(403);
+      expect(r.error).toMatch(/not authorized/i);
+    }
+  });
+
+  it("returns 403 when scope is expired", async () => {
+    const scope: AggregatorScope = {
+      ran: "RAN-000000000001",
+      rrn: "RRN-000000000002",
+      authorized_at: "2025-01-01T00:00:00Z",
+      authorized_by: "RAN-000000000001",
+      valid_until: "2025-12-31T23:59:59Z",
+    };
+    const env = makeEnv({
+      "aggregator-scope:RAN-000000000001/RRN-000000000002": JSON.stringify(scope),
+    });
+    const r = await assertAggregatorScopedFor(env, "RAN-000000000001", "RRN-000000000002");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(403);
+      expect(r.error).toMatch(/expired/i);
+    }
+  });
+});

--- a/functions/v2/_lib/aggregator-scope.ts
+++ b/functions/v2/_lib/aggregator-scope.ts
@@ -1,0 +1,47 @@
+/**
+ * Check whether an aggregator (by RAN) is authorized to attest for a robot (by RRN).
+ *
+ * KV key: aggregator-scope:RAN-NNN/RRN-MMM -> AggregatorScope
+ *
+ * Used by the compliance-bundle POST handler to enforce that a registered
+ * aggregator can only persist bundles for robots within its scope.
+ */
+
+import type { AggregatorScope } from "./types.js";
+
+export type ScopeOk = { ok: true };
+export type ScopeError = { ok: false; status: number; error: string };
+export type ScopeResult = ScopeOk | ScopeError;
+
+export async function assertAggregatorScopedFor(
+  env: { RRF_KV: KVNamespace },
+  aggregatorRan: `RAN-${string}`,
+  robotRrn: `RRN-${string}`,
+): Promise<ScopeResult> {
+  const key = `aggregator-scope:${aggregatorRan}/${robotRrn}`;
+  const raw = await env.RRF_KV.get(key, "text");
+  if (!raw) {
+    return {
+      ok: false,
+      status: 403,
+      error: `aggregator ${aggregatorRan} is not authorized to attest for ${robotRrn}`,
+    };
+  }
+  let scope: AggregatorScope;
+  try {
+    scope = JSON.parse(raw) as AggregatorScope;
+  } catch {
+    return { ok: false, status: 500, error: "Corrupt aggregator-scope record" };
+  }
+  if (scope.valid_until) {
+    const untilMs = Date.parse(scope.valid_until);
+    if (!Number.isNaN(untilMs) && untilMs <= Date.now()) {
+      return {
+        ok: false,
+        status: 403,
+        error: `aggregator scope for ${aggregatorRan}/${robotRrn} expired at ${scope.valid_until}`,
+      };
+    }
+  }
+  return { ok: true };
+}

--- a/functions/v2/_lib/jwt-verify.test.ts
+++ b/functions/v2/_lib/jwt-verify.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { verifyM2mTrustedJwt } from "./jwt-verify.js";
+
+function makeEnv(initial: Record<string, string> = {}, rootPubkey?: string) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(),
+      list: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+    ...(rootPubkey !== undefined ? { RRF_ROOT_PUBKEY: rootPubkey } : {}),
+  };
+}
+
+describe("verifyM2mTrustedJwt", () => {
+  it("rejects with 401 when Authorization header is missing", async () => {
+    const env = makeEnv();
+    const req = new Request("https://rrf.rcan.dev/v2/compliance-bundle", {
+      method: "POST",
+    });
+    const r = await verifyM2mTrustedJwt(env, req, "RRN-000000000001");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(401);
+      expect(r.error).toMatch(/Bearer/);
+    }
+  });
+
+  it("rejects with 401 when Authorization scheme is not Bearer", async () => {
+    const env = makeEnv();
+    const req = new Request("https://rrf.rcan.dev/v2/compliance-bundle", {
+      method:  "POST",
+      headers: { Authorization: "Basic dXNlcjpwYXNz" },
+    });
+    const r = await verifyM2mTrustedJwt(env, req, "RRN-000000000001");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(401);
+      expect(r.error).toMatch(/Bearer/);
+    }
+  });
+
+  it("returns 401 or 500 when RRF root pubkey is not provisioned", async () => {
+    // No KV entry, no env fallback. Token shape doesn't matter — but we provide
+    // a syntactically valid 3-part JWT so failure is from missing pubkey, not
+    // from token parsing.
+    const env = makeEnv();
+    const fakeJwt = [
+      btoa(JSON.stringify({ alg: "EdDSA", typ: "JWT" })).replace(/=/g, ""),
+      btoa(JSON.stringify({ iss: "rrf.rcan.dev", rrf_sig: "AAAA" })).replace(/=/g, ""),
+      "AAAA",
+    ].join(".");
+    const req = new Request("https://rrf.rcan.dev/v2/compliance-bundle", {
+      method:  "POST",
+      headers: { Authorization: `Bearer ${fakeJwt}` },
+    });
+    const r = await verifyM2mTrustedJwt(env, req, "RRN-000000000001");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect([401, 500]).toContain(r.status);
+    }
+  });
+
+  it("rejects malformed JWTs (not 3 parts) with 401", async () => {
+    const env = makeEnv();
+    const req = new Request("https://rrf.rcan.dev/v2/compliance-bundle", {
+      method:  "POST",
+      headers: { Authorization: "Bearer not-a-jwt" },
+    });
+    const r = await verifyM2mTrustedJwt(env, req, "RRN-000000000001");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(401);
+      expect(r.error).toMatch(/3 parts|Invalid JWT/);
+    }
+  });
+
+  it("rejects when JWT signature does not verify against the configured pubkey", async () => {
+    // Provide a real-shaped (but unrelated) Ed25519 SPKI public key so the import
+    // succeeds; the signature itself will then fail to verify against arbitrary bytes.
+    const realSpkiB64 =
+      "MCowBQYDK2VwAyEAGb9ECWmEzf6FQbrBZ9w7lshQhqowtrbLDFw4rXAxZuE=";
+    const env = makeEnv({
+      "rrf:root:pubkey": `-----BEGIN PUBLIC KEY-----\n${realSpkiB64}\n-----END PUBLIC KEY-----\n`,
+    });
+    const fakeJwt = [
+      btoa(JSON.stringify({ alg: "EdDSA", typ: "JWT" })).replace(/=/g, ""),
+      btoa(JSON.stringify({
+        iss:         "rrf.rcan.dev",
+        exp:         Math.floor(Date.now() / 1000) + 3600,
+        rcan_scopes: ["fleet.trusted"],
+        fleet_rrns:  ["RRN-000000000001"],
+        rrf_sig:     "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      })).replace(/=/g, ""),
+      "AAAA",
+    ].join(".");
+    const req = new Request("https://rrf.rcan.dev/v2/compliance-bundle", {
+      method:  "POST",
+      headers: { Authorization: `Bearer ${fakeJwt}` },
+    });
+    const r = await verifyM2mTrustedJwt(env, req, "RRN-000000000001");
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(401);
+      expect(r.error).toMatch(/signature verification failed/i);
+    }
+  });
+});

--- a/functions/v2/_lib/jwt-verify.ts
+++ b/functions/v2/_lib/jwt-verify.ts
@@ -1,0 +1,173 @@
+/**
+ * Verify a Bearer M2M_TRUSTED JWT for a given RRN scope.
+ *
+ * NOTE: rcan-ts.verifyM2mTrustedToken intentionally does NOT verify signatures
+ * (see its d.ts: "done server-side using the rcan-py SDK or castor.auth
+ * middleware"). This module performs Web Crypto Ed25519 SPKI verification
+ * directly against the RRF root pubkey published at
+ * functions/.well-known/rrf-root-pubkey.pem.
+ *
+ * Mirrors the signing-input reconstruction pattern from
+ * functions/v2/orchestrators/[id]/token.ts (strips rrf_sig before signing
+ * input is hashed; the emitted token's payload contains the embedded sig).
+ *
+ * Flow:
+ *   1. Extract Authorization: Bearer <jwt>
+ *   2. Fetch rrf:root:pubkey from KV (or env fallback)
+ *   3. Reconstruct signing input: b64u(header).b64u(payload-minus-rrf_sig)
+ *   4. Web Crypto Ed25519 SPKI verify
+ *   5. Assert claims.iss === "rrf.rcan.dev" and claims.exp > now
+ *   6. Assert claims.rcan_scopes includes "fleet.trusted"
+ *   7. Assert claims.fleet_rrns includes requiredRrn
+ */
+
+export interface JwtOk {
+  ok: true;
+  claims: Record<string, unknown>;
+}
+
+export interface JwtError {
+  ok: false;
+  status: number;
+  error: string;
+}
+
+export type JwtResult = JwtOk | JwtError;
+
+export interface JwtVerifyEnv {
+  RRF_KV: KVNamespace;
+  RRF_ROOT_PUBKEY?: string;
+}
+
+/** Decode URL-safe base64 to Uint8Array (Cloudflare Workers / atob-compatible). */
+function fromB64Url(s: string): Uint8Array {
+  // Convert base64url → base64
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/");
+  // Pad to multiple of 4
+  const pad = b64.length % 4 === 0 ? "" : "=".repeat(4 - (b64.length % 4));
+  return Uint8Array.from(atob(b64 + pad), (c) => c.charCodeAt(0));
+}
+
+/** Strip PEM framing + whitespace, return DER bytes. */
+function pemToDer(pem: string): Uint8Array {
+  const body = pem
+    .replace(/-----BEGIN PUBLIC KEY-----/g, "")
+    .replace(/-----END PUBLIC KEY-----/g, "")
+    .replace(/\s+/g, "");
+  return Uint8Array.from(atob(body), (c) => c.charCodeAt(0));
+}
+
+/** Resolve the RRF root pubkey PEM from KV (preferred) or env fallback. */
+async function getRootPubkeyPem(env: JwtVerifyEnv): Promise<string | null> {
+  const fromKv = await env.RRF_KV.get("rrf:root:pubkey", "text");
+  if (fromKv) return fromKv;
+  if (env.RRF_ROOT_PUBKEY) {
+    const b64 = env.RRF_ROOT_PUBKEY.trim();
+    return `-----BEGIN PUBLIC KEY-----\n${b64}\n-----END PUBLIC KEY-----\n`;
+  }
+  return null;
+}
+
+export async function verifyM2mTrustedJwt(
+  env: JwtVerifyEnv,
+  request: Request,
+  requiredRrn: `RRN-${string}`,
+): Promise<JwtResult> {
+  // 1. Extract Authorization: Bearer <jwt>
+  const authHeader = request.headers.get("Authorization") ?? "";
+  if (!authHeader.startsWith("Bearer ")) {
+    return { ok: false, status: 401, error: "Authorization: Bearer <jwt> required" };
+  }
+  const token = authHeader.slice("Bearer ".length).trim();
+  if (!token) {
+    return { ok: false, status: 401, error: "Authorization: Bearer <jwt> required" };
+  }
+
+  // 2. Token shape: header.payload.signature (3 parts)
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return { ok: false, status: 401, error: "Invalid JWT: expected 3 parts" };
+  }
+  const [headerB64, payloadB64, _sigB64] = parts;
+
+  let header: Record<string, unknown>;
+  let payload: Record<string, unknown>;
+  try {
+    header = JSON.parse(new TextDecoder().decode(fromB64Url(headerB64))) as Record<string, unknown>;
+    payload = JSON.parse(new TextDecoder().decode(fromB64Url(payloadB64))) as Record<string, unknown>;
+  } catch {
+    return { ok: false, status: 401, error: "Invalid JWT: malformed header or payload" };
+  }
+  if (!header || typeof header !== "object" || !payload || typeof payload !== "object") {
+    return { ok: false, status: 401, error: "Invalid JWT: malformed header or payload" };
+  }
+
+  // 3. Resolve RRF root pubkey (KV preferred, env fallback)
+  const pem = await getRootPubkeyPem(env);
+  if (!pem) {
+    return { ok: false, status: 500, error: "RRF root pubkey not provisioned" };
+  }
+
+  // 4. Extract embedded rrf_sig and reconstruct signing input
+  // (mirrors the mint at functions/v2/orchestrators/[id]/token.ts:84-87 —
+  // signing input is b64u(header).b64u(payload-minus-rrf_sig))
+  const rrfSig = payload["rrf_sig"];
+  if (typeof rrfSig !== "string" || rrfSig.length === 0) {
+    return { ok: false, status: 401, error: "Invalid JWT: missing rrf_sig in payload" };
+  }
+  const { rrf_sig: _omit, ...payloadWithoutSig } = payload;
+
+  const b64u = (s: string) =>
+    btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  const signingInput = `${b64u(JSON.stringify(header))}.${b64u(JSON.stringify(payloadWithoutSig))}`;
+
+  // 5. Web Crypto Ed25519 SPKI verify
+  let signatureValid = false;
+  try {
+    const derBytes = pemToDer(pem);
+    const key = await crypto.subtle.importKey(
+      "spki",
+      derBytes,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    const sigBytes = fromB64Url(rrfSig);
+    const encoder = new TextEncoder();
+    signatureValid = await crypto.subtle.verify(
+      { name: "Ed25519" },
+      key,
+      sigBytes,
+      encoder.encode(signingInput),
+    );
+  } catch {
+    signatureValid = false;
+  }
+  if (!signatureValid) {
+    return { ok: false, status: 401, error: "JWT signature verification failed" };
+  }
+
+  // 6. Claim assertions: iss + exp
+  if (payload["iss"] !== "rrf.rcan.dev") {
+    return { ok: false, status: 401, error: "Invalid issuer" };
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const exp = payload["exp"];
+  if (typeof exp !== "number" || exp <= now) {
+    return { ok: false, status: 401, error: "Token expired" };
+  }
+
+  // 7. rcan_scopes must include "fleet.trusted"
+  const scopes = payload["rcan_scopes"];
+  if (!Array.isArray(scopes) || !scopes.includes("fleet.trusted")) {
+    return { ok: false, status: 403, error: "Token missing fleet.trusted scope" };
+  }
+
+  // 8. fleet_rrns must include requiredRrn
+  const fleetRrns = payload["fleet_rrns"];
+  if (!Array.isArray(fleetRrns) || !fleetRrns.includes(requiredRrn)) {
+    return { ok: false, status: 403, error: `Token not scoped for ${requiredRrn}` };
+  }
+
+  return { ok: true, claims: payload };
+}

--- a/functions/v2/_lib/kid-resolve.test.ts
+++ b/functions/v2/_lib/kid-resolve.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveKidToAuthority } from "./kid-resolve.js";
+import type { KidMapping } from "./types.js";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+      list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+        keys: Object.keys(store)
+          .filter(k => k.startsWith(prefix))
+          .map(name => ({ name })),
+      })),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+    __store: store,
+  };
+}
+
+describe("resolveKidToAuthority", () => {
+  it("returns null when no kid:* entries match", async () => {
+    const { RRF_KV } = makeEnv();
+    const result = await resolveKidToAuthority(
+      { RRF_KV } as { RRF_KV: KVNamespace },
+      "missing-kid",
+      "2026-05-04T12:00:00Z",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns the active mapping when signed_at falls in [valid_from, valid_until)", async () => {
+    const mapping: KidMapping = {
+      ran: "RAN-000000000001",
+      valid_from: "2026-01-01T00:00:00Z",
+      valid_until: "2027-01-01T00:00:00Z",
+      registered_at: "2026-01-01T00:00:00Z",
+      registered_by: "RAN-000000000001",
+    };
+    const authority = {
+      ran: "RAN-000000000001",
+      organization: "OpenCastor Ops",
+      signing_pub: "FAKE-ED25519-PUB",
+      pq_signing_pub: "FAKE-ML-DSA-PUB",
+    };
+    const { RRF_KV } = makeEnv({
+      "kid:ops-aggregator-2026-05:2026-01-01T00:00:00Z": JSON.stringify(mapping),
+      "authority:RAN-000000000001": JSON.stringify(authority),
+    });
+    const result = await resolveKidToAuthority(
+      { RRF_KV } as { RRF_KV: KVNamespace },
+      "ops-aggregator-2026-05",
+      "2026-05-04T12:00:00Z",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.ran).toBe("RAN-000000000001");
+    expect(result!.signing_pub).toBe("FAKE-ED25519-PUB");
+  });
+
+  it("rejects mappings where signed_at predates valid_from", async () => {
+    const mapping: KidMapping = {
+      ran: "RAN-000000000001",
+      valid_from: "2026-06-01T00:00:00Z",
+      registered_at: "2026-06-01T00:00:00Z",
+      registered_by: "RAN-000000000001",
+    };
+    const authority = { ran: "RAN-000000000001", signing_pub: "X", pq_signing_pub: "Y" };
+    const { RRF_KV } = makeEnv({
+      "kid:k:2026-06-01T00:00:00Z": JSON.stringify(mapping),
+      "authority:RAN-000000000001": JSON.stringify(authority),
+    });
+    const result = await resolveKidToAuthority(
+      { RRF_KV } as { RRF_KV: KVNamespace },
+      "k",
+      "2026-05-04T12:00:00Z",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects mappings where signed_at >= valid_until", async () => {
+    const mapping: KidMapping = {
+      ran: "RAN-000000000001",
+      valid_from: "2026-01-01T00:00:00Z",
+      valid_until: "2026-04-01T00:00:00Z",
+      registered_at: "2026-01-01T00:00:00Z",
+      registered_by: "RAN-000000000001",
+    };
+    const authority = { ran: "RAN-000000000001", signing_pub: "X", pq_signing_pub: "Y" };
+    const { RRF_KV } = makeEnv({
+      "kid:k:2026-01-01T00:00:00Z": JSON.stringify(mapping),
+      "authority:RAN-000000000001": JSON.stringify(authority),
+    });
+    const result = await resolveKidToAuthority(
+      { RRF_KV } as { RRF_KV: KVNamespace },
+      "k",
+      "2026-05-04T12:00:00Z",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("picks the most-recent valid mapping when multiple match (rotation overlap)", async () => {
+    const m1: KidMapping = {
+      ran: "RAN-000000000001",
+      valid_from: "2026-01-01T00:00:00Z",
+      valid_until: "2026-06-01T00:00:00Z",
+      registered_at: "2026-01-01T00:00:00Z",
+      registered_by: "RAN-000000000001",
+    };
+    const m2: KidMapping = {
+      ran: "RAN-000000000002",
+      valid_from: "2026-05-15T00:00:00Z",
+      registered_at: "2026-05-15T00:00:00Z",
+      registered_by: "RAN-000000000002",
+    };
+    const a1 = { ran: "RAN-000000000001", signing_pub: "X1", pq_signing_pub: "Y1" };
+    const a2 = { ran: "RAN-000000000002", signing_pub: "X2", pq_signing_pub: "Y2" };
+    const { RRF_KV } = makeEnv({
+      "kid:k:2026-01-01T00:00:00Z": JSON.stringify(m1),
+      "kid:k:2026-05-15T00:00:00Z": JSON.stringify(m2),
+      "authority:RAN-000000000001": JSON.stringify(a1),
+      "authority:RAN-000000000002": JSON.stringify(a2),
+    });
+    // signed_at falls in BOTH windows; resolver picks the most-recent registered_at.
+    const result = await resolveKidToAuthority(
+      { RRF_KV } as { RRF_KV: KVNamespace },
+      "k",
+      "2026-05-20T12:00:00Z",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.ran).toBe("RAN-000000000002");
+  });
+});

--- a/functions/v2/_lib/kid-resolve.ts
+++ b/functions/v2/_lib/kid-resolve.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolve a bundle_signature.kid to the registered authority record,
+ * filtered by the bundle's signed_at falling within the kid's validity window.
+ *
+ * KV layout:
+ *   kid:<kid>:<registered_at>  -> KidMapping (versioned per registration)
+ *   authority:RAN-NNN          -> AuthorityRecord
+ *
+ * If multiple kid:<kid>:* entries are valid for the signed_at, the resolver picks
+ * the most-recent registered_at (defensive against operator error during rotation).
+ */
+
+import type { KidMapping } from "./types.js";
+
+export interface AuthorityForVerify {
+  ran: `RAN-${string}`;
+  signing_pub: string;       // Ed25519 base64
+  pq_signing_pub: string;    // ML-DSA-65 base64
+  organization?: string;
+  pq_kid?: string;
+}
+
+export async function resolveKidToAuthority(
+  env: { RRF_KV: KVNamespace },
+  kid: string,
+  signedAt: string,
+): Promise<AuthorityForVerify | null> {
+  const list = await env.RRF_KV.list({ prefix: `kid:${kid}:` });
+  if (list.keys.length === 0) return null;
+
+  const signedAtMs = Date.parse(signedAt);
+  if (Number.isNaN(signedAtMs)) return null;
+
+  type Candidate = { mapping: KidMapping; key: string };
+  const candidates: Candidate[] = [];
+  for (const k of list.keys) {
+    const raw = await env.RRF_KV.get(k.name, "text");
+    if (!raw) continue;
+    let mapping: KidMapping;
+    try { mapping = JSON.parse(raw) as KidMapping; }
+    catch { continue; }
+    const fromMs = Date.parse(mapping.valid_from);
+    const untilMs = mapping.valid_until ? Date.parse(mapping.valid_until) : Number.POSITIVE_INFINITY;
+    if (Number.isNaN(fromMs)) continue;
+    if (signedAtMs < fromMs) continue;
+    if (signedAtMs >= untilMs) continue;
+    candidates.push({ mapping, key: k.name });
+  }
+  if (candidates.length === 0) return null;
+  // Pick the most-recent registered_at (lexicographic on ISO-8601 = chronological).
+  candidates.sort((a, b) => b.mapping.registered_at.localeCompare(a.mapping.registered_at));
+  const winner = candidates[0].mapping;
+
+  const authRaw = await env.RRF_KV.get(`authority:${winner.ran}`, "text");
+  if (!authRaw) return null;
+  try {
+    const auth = JSON.parse(authRaw) as AuthorityForVerify;
+    return auth;
+  } catch {
+    return null;
+  }
+}

--- a/functions/v2/_lib/rrf-log-sign.test.ts
+++ b/functions/v2/_lib/rrf-log-sign.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { signLogEntry } from "./rrf-log-sign.js";
+import { canonicalJson } from "rcan-ts";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(), list: vi.fn(), delete: vi.fn(),
+    } as unknown as KVNamespace,
+  };
+}
+
+async function mkRootKey(): Promise<{ priv_b64: string; pub_pem: string }> {
+  const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+  const privDer = await crypto.subtle.exportKey("pkcs8", (kp as CryptoKeyPair).privateKey);
+  const pubDer = await crypto.subtle.exportKey("spki", (kp as CryptoKeyPair).publicKey);
+  const b64 = (b: ArrayBuffer) => btoa(String.fromCharCode(...new Uint8Array(b)));
+  return {
+    priv_b64: b64(privDer),
+    pub_pem: `-----BEGIN PUBLIC KEY-----\n${b64(pubDer)}\n-----END PUBLIC KEY-----\n`,
+  };
+}
+
+describe("signLogEntry", () => {
+  it("produces a valid Ed25519 signature over canonical entry bytes", async () => {
+    const root = await mkRootKey();
+    const env = makeEnv({
+      "rrf:root:privkey": root.priv_b64,
+      "rrf:root:pubkey": root.pub_pem,
+    });
+    const entry = {
+      bundle_id: "bundle_test",
+      rrn: "RRN-000000000002",
+      transparency_log_index: 42,
+    };
+    const sig = await signLogEntry(env, entry);
+    expect(sig.kid).toBe("rrf-root");
+    expect(sig.alg).toBe("Ed25519");
+    expect(sig.sig).toMatch(/^[A-Za-z0-9+/=]+$/);
+
+    // Verify the signature against the entry's canonical bytes.
+    const pub = await crypto.subtle.importKey(
+      "spki",
+      Uint8Array.from(atob(root.pub_pem.split("\n").slice(1, -2).join("")), c => c.charCodeAt(0)),
+      { name: "Ed25519" }, false, ["verify"],
+    );
+    const sigBytes = Uint8Array.from(atob(sig.sig), c => c.charCodeAt(0));
+    const canon = canonicalJson(entry);
+    const ok = await crypto.subtle.verify("Ed25519", pub, sigBytes, canon);
+    expect(ok).toBe(true);
+  });
+
+  it("throws when rrf:root:privkey is not configured", async () => {
+    const env = makeEnv();
+    await expect(signLogEntry(env, { bundle_id: "x" })).rejects.toThrow(/privkey not configured/i);
+  });
+});

--- a/functions/v2/_lib/rrf-log-sign.ts
+++ b/functions/v2/_lib/rrf-log-sign.ts
@@ -1,0 +1,40 @@
+/**
+ * Sign a transparency-log entry with the RRF root Ed25519 key.
+ *
+ * KV layout:
+ *   rrf:root:privkey  -> base64 PKCS8 DER (set via wrangler kv:key put)
+ *   rrf:root:pubkey   -> PEM (existing; served by .well-known/rrf-root-pubkey.pem)
+ *
+ * Used by compliance-bundle POST to bind the public proof to the RRF
+ * authority. Signature is over canonicalJson(entry) — the entry shape
+ * MUST match what the proof endpoint returns.
+ */
+
+import { canonicalJson } from "rcan-ts";
+
+export interface RrfLogSignature {
+  kid: "rrf-root";
+  alg: "Ed25519";
+  sig: string;  // base64 standard
+}
+
+export async function signLogEntry(
+  env: { RRF_KV: KVNamespace },
+  entry: Record<string, unknown>,
+): Promise<RrfLogSignature> {
+  const privB64 = await env.RRF_KV.get("rrf:root:privkey", "text");
+  if (!privB64) {
+    throw new Error("rrf:root:privkey not configured (run scripts/init-rrf-log-signing-key.ts)");
+  }
+
+  const privBytes = Uint8Array.from(atob(privB64.trim()), c => c.charCodeAt(0));
+  const key = await crypto.subtle.importKey(
+    "pkcs8", privBytes, { name: "Ed25519" }, false, ["sign"],
+  );
+
+  const canon = canonicalJson(entry);
+  const sigBuffer = await crypto.subtle.sign("Ed25519", key, canon);
+  const sig = btoa(String.fromCharCode(...new Uint8Array(sigBuffer)));
+
+  return { kid: "rrf-root", alg: "Ed25519", sig };
+}

--- a/functions/v2/_lib/types.ts
+++ b/functions/v2/_lib/types.ts
@@ -160,3 +160,45 @@ export interface RegistryEntry {
   registered_at: string;
   summary: Record<string, unknown>;
 }
+
+// === Compliance bundle intake — Plan 4 Phase 3 ===
+
+export type KidMapping = {
+  ran: `RAN-${string}`;
+  valid_from: string;        // ISO-8601 UTC
+  valid_until?: string;      // ISO-8601 UTC; absent = currently active
+  registered_at: string;     // ISO-8601 UTC
+  registered_by: `RAN-${string}`;
+};
+
+export type AggregatorScope = {
+  ran: `RAN-${string}`;            // aggregator
+  rrn: `RRN-${string}`;            // robot the aggregator may attest for
+  authorized_at: string;
+  authorized_by: `RAN-${string}`;
+  valid_until?: string;
+};
+
+export type ComplianceBundleEntry = {
+  bundle_id: string;
+  rrn: `RRN-${string}`;
+  schema_version: string;
+  signed_at: string;
+  robot_md_sha256: string;
+  matrix_version?: string;
+  artifact_types: string[];
+  transparency_log_index: number;
+  logged_at: string;
+  bundle_signature: {
+    kid: string;
+    alg: ["Ed25519", "ML-DSA-65"];
+    sig: { ed25519: string; ml_dsa: string; ed25519_pub: string };
+  };
+  rrf_log_signature: { kid: string; alg: "Ed25519"; sig: string };
+  // Full payload (artifacts) lives at compliance-bundle:<bundle_id>
+  // separately for Bearer-gated full GET access.
+};
+
+export type ComplianceBundleProof = Omit<ComplianceBundleEntry, never>;
+// proof IS the entry — same fields, served at /v2/compliance-bundle/{id}/proof
+// without the artifact bodies.

--- a/functions/v2/_lib/verify-bundle-hybrid.test.ts
+++ b/functions/v2/_lib/verify-bundle-hybrid.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { verifyBundleHybrid } from "./verify-bundle-hybrid.js";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(),
+      list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+        keys: Object.keys(store).filter(k => k.startsWith(prefix)).map(name => ({ name })),
+      })),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+  };
+}
+
+describe("verifyBundleHybrid", () => {
+  it("returns 403 when kid does not resolve to any authority", async () => {
+    const env = makeEnv();
+    const payload = {
+      schema_version: "1.0",
+      bundle_id: "b1",
+      rrn: "RRN-000000000002",
+      signed_at: "2026-05-04T12:00:00Z",
+      bundle_signature: { kid: "missing-kid", alg: ["Ed25519", "ML-DSA-65"], sig: { ed25519: "x", ml_dsa: "y", ed25519_pub: "z" } },
+    };
+    const r = await verifyBundleHybrid(env, payload);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(403);
+  });
+
+  it("returns 400 when bundle_signature is missing", async () => {
+    const env = makeEnv();
+    const r = await verifyBundleHybrid(env, { schema_version: "1.0", rrn: "RRN-000000000002", signed_at: "2026-05-04T12:00:00Z" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
+
+  it("returns 400 when signed_at is not a string", async () => {
+    const env = makeEnv();
+    const payload = {
+      schema_version: "1.0",
+      rrn: "RRN-000000000002",
+      signed_at: 12345,
+      bundle_signature: { kid: "ops-aggregator-2026-05", alg: ["Ed25519", "ML-DSA-65"], sig: { ed25519: "x", ml_dsa: "y", ed25519_pub: "z" } },
+    };
+    const r = await verifyBundleHybrid(env, payload);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
+
+  it("returns 400 when bundle_signature.sig is missing required fields", async () => {
+    const env = makeEnv();
+    const payload = {
+      schema_version: "1.0",
+      rrn: "RRN-000000000002",
+      signed_at: "2026-05-04T12:00:00Z",
+      bundle_signature: { kid: "ops-aggregator-2026-05", alg: ["Ed25519", "ML-DSA-65"], sig: { ed25519: "x" } },
+    };
+    const r = await verifyBundleHybrid(env, payload);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
+
+  // Happy-path hybrid verification is exercised end-to-end in Task 14's
+  // smoke test (which mints real test keypairs + signs + posts + verifies).
+});

--- a/functions/v2/_lib/verify-bundle-hybrid.ts
+++ b/functions/v2/_lib/verify-bundle-hybrid.ts
@@ -1,0 +1,131 @@
+/**
+ * Verify a compliance bundle's hybrid (Ed25519 + ML-DSA-65) signature.
+ *
+ * The aggregator (opencastor-ops monitor/compliance_bundle.py) signs:
+ *   data = canonical_json(payload, exclude="bundle_signature")
+ * with a `_Signer` that produces:
+ *   bundle_signature = {
+ *     kid: <string>,
+ *     alg: ["Ed25519", "ML-DSA-65"],
+ *     sig: { ed25519: <b64>, ml_dsa: <b64>, ed25519_pub: <b64-informational> },
+ *   }
+ *
+ * This verifier:
+ *   1. Validates bundle_signature shape + signed_at is a string.
+ *   2. Resolves bundle_signature.kid → AuthorityForVerify via KV (kid + window).
+ *   3. Recomputes canonicalJson(payload - bundle_signature) — the SAME bytes
+ *      the aggregator signed.
+ *   4. Calls rcan-ts.verifyHybrid(ed25519Pub, mlDsaPub, msg, sig) where:
+ *      - ed25519Pub is sourced from authority.signing_pub (TRUST ANCHOR)
+ *        not from bundle_signature.sig.ed25519_pub (informational; could lie).
+ *      - mlDsaPub is sourced from authority.pq_signing_pub.
+ *
+ * SPEC DEVIATION (controller-authorized 2026-05-04, second instance after
+ * Task 6): the plan body's Step 3 proposed reshaping
+ *   { bundle_signature → sig, kid → pq_kid }
+ * and calling rcan-ts.verifyBody. That cannot work because:
+ *   1. verifyBody requires signed["pq_signing_pub"] string field — the
+ *      reshape adds pq_kid and sig but NOT pq_signing_pub, so verifyBody
+ *      returns false at the field-presence check.
+ *   2. verifyBody internally computes canonicalJson(signed - sig), which
+ *      includes the added pq_kid + (missing) pq_signing_pub. Those bytes
+ *      will NOT match canonical_json(payload, exclude="bundle_signature")
+ *      that the aggregator actually signed.
+ *
+ * Therefore we use verifyHybrid directly — the right primitive — so that
+ * sign and verify operate on the SAME canonical bytes.
+ */
+
+import { canonicalJson, verifyHybrid, type HybridSignature } from "rcan-ts";
+import { resolveKidToAuthority } from "./kid-resolve.js";
+
+export type VerifyOk = { ok: true; ran: `RAN-${string}` };
+export type VerifyError = { ok: false; status: number; error: string };
+export type VerifyHybridResult = VerifyOk | VerifyError;
+
+interface BundleSignature {
+  kid: string;
+  alg: string[];
+  sig: {
+    ed25519: string;
+    ml_dsa: string;
+    ed25519_pub: string;
+  };
+}
+
+function isBundleSignature(v: unknown): v is BundleSignature {
+  if (!v || typeof v !== "object") return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.kid !== "string") return false;
+  if (!Array.isArray(o.alg)) return false;
+  if (!o.sig || typeof o.sig !== "object") return false;
+  const s = o.sig as Record<string, unknown>;
+  if (typeof s.ed25519 !== "string") return false;
+  if (typeof s.ml_dsa !== "string") return false;
+  if (typeof s.ed25519_pub !== "string") return false;
+  return true;
+}
+
+function b64ToBytes(s: string): Uint8Array {
+  return Uint8Array.from(atob(s), c => c.charCodeAt(0));
+}
+
+export async function verifyBundleHybrid(
+  env: { RRF_KV: KVNamespace },
+  payload: Record<string, unknown>,
+): Promise<VerifyHybridResult> {
+  const bsig = payload.bundle_signature;
+  if (!isBundleSignature(bsig)) {
+    return { ok: false, status: 400, error: "bundle_signature missing or malformed" };
+  }
+  const signedAt = payload.signed_at;
+  if (typeof signedAt !== "string") {
+    return { ok: false, status: 400, error: "signed_at must be an ISO-8601 string" };
+  }
+
+  const auth = await resolveKidToAuthority(env, bsig.kid, signedAt);
+  if (!auth) {
+    return {
+      ok: false,
+      status: 403,
+      error: "kid not registered or signed_at outside validity window",
+    };
+  }
+
+  // Recompute the bytes the aggregator signed: canonical_json(payload - bundle_signature).
+  // Destructure to drop the field; canonicalJson the rest.
+  const { bundle_signature: _bsig, ...rest } = payload;
+  void _bsig;
+  const canonBytes = canonicalJson(rest);
+
+  let ed25519Sig: Uint8Array;
+  let mlDsaSig: Uint8Array;
+  let ed25519Pub: Uint8Array;
+  let mlDsaPub: Uint8Array;
+  try {
+    ed25519Sig = b64ToBytes(bsig.sig.ed25519);
+    mlDsaSig = b64ToBytes(bsig.sig.ml_dsa);
+    ed25519Pub = b64ToBytes(auth.signing_pub);
+    mlDsaPub = b64ToBytes(auth.pq_signing_pub);
+  } catch {
+    return { ok: false, status: 400, error: "bundle_signature contains invalid base64" };
+  }
+
+  const sig: HybridSignature = {
+    profile: "pqc-hybrid-v1",
+    ed25519Sig,
+    mlDsaSig,
+  };
+
+  // verifyHybrid is sync; noble/curves can throw on invalid byte lengths.
+  let ok = false;
+  try {
+    ok = verifyHybrid(ed25519Pub, mlDsaPub, canonBytes, sig);
+  } catch {
+    ok = false;
+  }
+  if (!ok) {
+    return { ok: false, status: 403, error: "bundle hybrid signature did not verify" };
+  }
+  return { ok: true, ran: auth.ran };
+}

--- a/functions/v2/compliance-bundle/[bundle_id]/index.ts
+++ b/functions/v2/compliance-bundle/[bundle_id]/index.ts
@@ -1,0 +1,45 @@
+/**
+ * GET /v2/compliance-bundle/{bundle_id}
+ * Bearer-gated full bundle return. Bearer = M2M_TRUSTED JWT.
+ */
+
+import { verifyM2mTrustedJwt } from "../../_lib/jwt-verify.js";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+  RRF_ROOT_PUBKEY?: string;
+}
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env, "bundle_id"> = async ({ env, request, params }) => {
+  const bundleId = params["bundle_id"] as string;
+  if (!bundleId || !bundleId.startsWith("bundle_")) {
+    return json({ error: "bundle_id missing or malformed" }, 400);
+  }
+
+  // Read first to find the RRN — we need it for the JWT scope check.
+  const raw = await env.RRF_KV.get(`compliance-bundle:${bundleId}`, "text");
+  if (!raw) return json({ error: `bundle ${bundleId} not found` }, 404);
+
+  let payload: Record<string, unknown>;
+  try { payload = JSON.parse(raw) as Record<string, unknown>; }
+  catch { return json({ error: "corrupt bundle record" }, 500); }
+
+  const rrn = payload["rrn"];
+  if (typeof rrn !== "string" || !/^RRN-\d{12}$/.test(rrn)) {
+    return json({ error: "stored bundle has malformed rrn" }, 500);
+  }
+
+  const jwtResult = await verifyM2mTrustedJwt(env, request, rrn as `RRN-${string}`);
+  if (!jwtResult.ok) {
+    return json({ error: jwtResult.error }, jwtResult.status);
+  }
+
+  return json(payload, 200);
+};

--- a/functions/v2/compliance-bundle/[bundle_id]/proof.test.ts
+++ b/functions/v2/compliance-bundle/[bundle_id]/proof.test.ts
@@ -1,0 +1,64 @@
+// functions/v2/compliance-bundle/[bundle_id]/proof.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { onRequestGet } from "./proof.js";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(),
+      list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+        keys: Object.keys(store).filter(k => k.startsWith(prefix)).map(name => ({ name })),
+        list_complete: true,
+      })),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+  };
+}
+
+describe("GET /v2/compliance-bundle/{id}/proof", () => {
+  it("returns 404 when bundle is not in the log", async () => {
+    const env = { RRF_KV: makeEnv().RRF_KV };
+    const res = await onRequestGet({
+      env,
+      request: new Request("https://x"),
+      params: { bundle_id: "bundle_nonexistent" },
+    } as any);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when bundle_id is malformed", async () => {
+    const env = { RRF_KV: makeEnv().RRF_KV };
+    const res = await onRequestGet({
+      env,
+      request: new Request("https://x"),
+      params: { bundle_id: "not-a-bundle" },
+    } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 + entry shape when bundle is in the log", async () => {
+    const entry = {
+      bundle_id: "bundle_test",
+      rrn: "RRN-000000000002",
+      schema_version: "1.0",
+      signed_at: "2026-05-04T12:00:00Z",
+      transparency_log_index: 42,
+      bundle_signature: { kid: "k", alg: ["Ed25519", "ML-DSA-65"], sig: { ed25519: "x", ml_dsa: "y", ed25519_pub: "z" } },
+      rrf_log_signature: { kid: "rrf-root", alg: "Ed25519", sig: "abc" },
+    };
+    const env = { RRF_KV: makeEnv({
+      "compliance-bundle-log:000000000042": JSON.stringify(entry),
+    }).RRF_KV };
+    const res = await onRequestGet({
+      env,
+      request: new Request("https://x"),
+      params: { bundle_id: "bundle_test" },
+    } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.bundle_id).toBe("bundle_test");
+    expect(body.transparency_log_index).toBe(42);
+  });
+});

--- a/functions/v2/compliance-bundle/[bundle_id]/proof.ts
+++ b/functions/v2/compliance-bundle/[bundle_id]/proof.ts
@@ -29,19 +29,24 @@ export const onRequestGet: PagesFunction<Env, "bundle_id"> = async ({ env, param
   }
 
   // Locate the log-index key for this bundle_id by scanning the index keys.
-  // For O(1) retrieval we'd add a bundle_id -> index mapping; for v1 the scan
-  // is acceptable at current traffic.
-  const list = await env.RRF_KV.list({ prefix: "compliance-bundle-log:" });
-  for (const k of list.keys) {
-    const raw = await env.RRF_KV.get(k.name, "text");
-    if (!raw) continue;
-    let entry: { bundle_id?: string };
-    try { entry = JSON.parse(raw) as { bundle_id?: string }; }
-    catch { continue; }
-    if (entry.bundle_id === bundleId) {
-      return json(entry, 200);
+  // Paginate to handle >1000 entries (Cloudflare KV list page cap).
+  // For O(1) retrieval we'd add a bundle_id -> index mapping; for v1 the
+  // paginated scan is acceptable at current traffic.
+  let cursor: string | undefined;
+  do {
+    const list = await env.RRF_KV.list({ prefix: "compliance-bundle-log:", cursor });
+    for (const k of list.keys) {
+      const raw = await env.RRF_KV.get(k.name, "text");
+      if (!raw) continue;
+      let entry: { bundle_id?: string };
+      try { entry = JSON.parse(raw) as { bundle_id?: string }; }
+      catch { continue; }
+      if (entry.bundle_id === bundleId) {
+        return json(entry, 200);
+      }
     }
-  }
+    cursor = list.list_complete ? undefined : list.cursor ?? undefined;
+  } while (cursor);
 
   return json({ error: `bundle ${bundleId} not found in transparency log` }, 404);
 };

--- a/functions/v2/compliance-bundle/[bundle_id]/proof.ts
+++ b/functions/v2/compliance-bundle/[bundle_id]/proof.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /v2/compliance-bundle/{bundle_id}/proof
+ *
+ * Public, no auth. Returns the metadata-only ComplianceBundleEntry shape:
+ * everything except the artifact bodies. Verifiable offline via:
+ *   1. Fetch this proof.
+ *   2. Fetch /.well-known/rrf-root-pubkey.pem.
+ *   3. Verify rrf_log_signature against the canonical entry bytes.
+ *
+ * Optionally also verify bundle_signature against the kid-mapped aggregator
+ * pubkey (kid resolve via the public kid:* index).
+ */
+
+export interface Env {
+  RRF_KV: KVNamespace;
+}
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env, "bundle_id"> = async ({ env, params }) => {
+  const bundleId = params["bundle_id"] as string;
+  if (!bundleId || !bundleId.startsWith("bundle_")) {
+    return json({ error: "bundle_id missing or malformed" }, 400);
+  }
+
+  // Locate the log-index key for this bundle_id by scanning the index keys.
+  // For O(1) retrieval we'd add a bundle_id -> index mapping; for v1 the scan
+  // is acceptable at current traffic.
+  const list = await env.RRF_KV.list({ prefix: "compliance-bundle-log:" });
+  for (const k of list.keys) {
+    const raw = await env.RRF_KV.get(k.name, "text");
+    if (!raw) continue;
+    let entry: { bundle_id?: string };
+    try { entry = JSON.parse(raw) as { bundle_id?: string }; }
+    catch { continue; }
+    if (entry.bundle_id === bundleId) {
+      return json(entry, 200);
+    }
+  }
+
+  return json({ error: `bundle ${bundleId} not found in transparency log` }, 404);
+};

--- a/functions/v2/compliance-bundle/handlers/v10.ts
+++ b/functions/v2/compliance-bundle/handlers/v10.ts
@@ -1,0 +1,105 @@
+/**
+ * Schema v1.0 handler for /v2/compliance-bundle POST.
+ *
+ * Flow:
+ *   1. Verify hybrid bundle_signature via verifyBundleHybrid (Task 8).
+ *   2. Resolve aggregator RAN -> RRN scope via assertAggregatorScopedFor (Task 5).
+ *   3. Idempotency: 409 if compliance-bundle:<bundle_id> already in KV.
+ *   4. Increment counter:compliance-bundle-log -> N.
+ *   5. Compute logged_at + artifact_types, build entry.
+ *   6. Sign entry with rrf-log-sign (Task 7).
+ *   7. Write counter, log-index key, full payload key (3 KV writes).
+ *   8. Return {bundle_id, rrn, transparency_log_index}.
+ */
+
+import type { ComplianceBundleEntry } from "../../_lib/types.js";
+import { verifyBundleHybrid } from "../../_lib/verify-bundle-hybrid.js";
+import { assertAggregatorScopedFor } from "../../_lib/aggregator-scope.js";
+import { signLogEntry } from "../../_lib/rrf-log-sign.js";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+}
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function handleV10(
+  payload: Record<string, unknown>,
+  env: Env,
+): Promise<Response> {
+  const bundleId = payload["bundle_id"];
+  const rrn = payload["rrn"];
+  if (typeof bundleId !== "string" || !bundleId.startsWith("bundle_")) {
+    return json({ error: "bundle_id missing or malformed" }, 400);
+  }
+  if (typeof rrn !== "string" || !/^RRN-\d{12}$/.test(rrn)) {
+    return json({ error: "rrn missing or malformed" }, 400);
+  }
+
+  // 1. Verify hybrid bundle_signature.
+  const verifyResult = await verifyBundleHybrid(env, payload);
+  if (!verifyResult.ok) {
+    return json({ error: verifyResult.error }, verifyResult.status);
+  }
+  const aggregatorRan = verifyResult.ran;
+
+  // 2. Aggregator -> RRN scope.
+  const scopeResult = await assertAggregatorScopedFor(env, aggregatorRan, rrn as `RRN-${string}`);
+  if (!scopeResult.ok) {
+    return json({ error: scopeResult.error }, scopeResult.status);
+  }
+
+  // 3. Idempotency.
+  const existing = await env.RRF_KV.get(`compliance-bundle:${bundleId}`, "text");
+  if (existing) {
+    return json({ error: `bundle_id ${bundleId} already exists in transparency log` }, 409);
+  }
+
+  // 4. Counter increment. NOTE: get→put races under concurrent POSTs (spec D6
+  // accepts this; matches authorities/register.ts pattern).
+  const counterStr = await env.RRF_KV.get("counter:compliance-bundle-log", "text");
+  const next = (counterStr ? parseInt(counterStr, 10) : 0) + 1;
+
+  // 5. Build the log entry.
+  const artifacts = (payload["artifacts"] ?? []) as Array<{ artifact_type?: string }>;
+  const artifactTypes = Array.from(new Set(
+    artifacts.map(a => a.artifact_type).filter((t): t is string => typeof t === "string")
+  )).sort();
+  const loggedAt = new Date().toISOString();
+  const entry: Omit<ComplianceBundleEntry, "rrf_log_signature"> = {
+    bundle_id: bundleId,
+    rrn: rrn as `RRN-${string}`,
+    schema_version: payload["schema_version"] as string,
+    signed_at: payload["signed_at"] as string,
+    robot_md_sha256: payload["robot_md_sha256"] as string,
+    matrix_version: payload["matrix_version"] as string | undefined,
+    artifact_types: artifactTypes,
+    transparency_log_index: next,
+    logged_at: loggedAt,
+    bundle_signature: payload["bundle_signature"] as ComplianceBundleEntry["bundle_signature"],
+  };
+
+  // 6. Sign the entry.
+  const rrfLogSig = await signLogEntry(env, entry);
+  const fullEntry: ComplianceBundleEntry = { ...entry, rrf_log_signature: rrfLogSig };
+
+  // 7. Three KV writes.
+  await env.RRF_KV.put(
+    `compliance-bundle:${bundleId}`,
+    JSON.stringify({ ...payload, transparency_log_index: next, logged_at: loggedAt, rrf_log_signature: rrfLogSig }),
+    { expirationTtl: 365 * 24 * 3600 * 10 },  // 10y retention
+  );
+  await env.RRF_KV.put(
+    `compliance-bundle-log:${String(next).padStart(12, "0")}`,
+    JSON.stringify(fullEntry),
+    { expirationTtl: 365 * 24 * 3600 * 10 },
+  );
+  await env.RRF_KV.put("counter:compliance-bundle-log", String(next));
+
+  return json({ bundle_id: bundleId, rrn, transparency_log_index: next }, 201);
+}

--- a/functions/v2/compliance-bundle/handlers/v10.ts
+++ b/functions/v2/compliance-bundle/handlers/v10.ts
@@ -40,6 +40,15 @@ export async function handleV10(
   if (typeof rrn !== "string" || !/^RRN-\d{12}$/.test(rrn)) {
     return json({ error: "rrn missing or malformed" }, 400);
   }
+  if (typeof payload["robot_md_sha256"] !== "string") {
+    return json({ error: "robot_md_sha256 missing or not a string" }, 400);
+  }
+  if (typeof payload["schema_version"] !== "string") {
+    return json({ error: "schema_version missing or not a string" }, 400);
+  }
+  if (typeof payload["signed_at"] !== "string") {
+    return json({ error: "signed_at missing or not a string" }, 400);
+  }
 
   // 1. Verify hybrid bundle_signature.
   const verifyResult = await verifyBundleHybrid(env, payload);
@@ -65,8 +74,10 @@ export async function handleV10(
   const counterStr = await env.RRF_KV.get("counter:compliance-bundle-log", "text");
   const next = (counterStr ? parseInt(counterStr, 10) : 0) + 1;
 
-  // 5. Build the log entry.
-  const artifacts = (payload["artifacts"] ?? []) as Array<{ artifact_type?: string }>;
+  // 5. Build the log entry. Defensive: artifacts may be malformed even when
+  // the hybrid sig is valid (the verifier checks crypto, not artifact shape).
+  const artifactsRaw = payload["artifacts"];
+  const artifacts: Array<{ artifact_type?: unknown }> = Array.isArray(artifactsRaw) ? artifactsRaw : [];
   const artifactTypes = Array.from(new Set(
     artifacts.map(a => a.artifact_type).filter((t): t is string => typeof t === "string")
   )).sort();
@@ -88,18 +99,19 @@ export async function handleV10(
   const rrfLogSig = await signLogEntry(env, entry);
   const fullEntry: ComplianceBundleEntry = { ...entry, rrf_log_signature: rrfLogSig };
 
-  // 7. Three KV writes.
-  await env.RRF_KV.put(
-    `compliance-bundle:${bundleId}`,
-    JSON.stringify({ ...payload, transparency_log_index: next, logged_at: loggedAt, rrf_log_signature: rrfLogSig }),
-    { expirationTtl: 365 * 24 * 3600 * 10 },  // 10y retention
-  );
+  // 7. Three KV writes — counter FIRST so partial-write failures produce
+  // orphaned (wasted-index) records rather than incoherent (lying) records.
+  await env.RRF_KV.put("counter:compliance-bundle-log", String(next));
   await env.RRF_KV.put(
     `compliance-bundle-log:${String(next).padStart(12, "0")}`,
     JSON.stringify(fullEntry),
     { expirationTtl: 365 * 24 * 3600 * 10 },
   );
-  await env.RRF_KV.put("counter:compliance-bundle-log", String(next));
+  await env.RRF_KV.put(
+    `compliance-bundle:${bundleId}`,
+    JSON.stringify({ ...payload, transparency_log_index: next, logged_at: loggedAt, rrf_log_signature: rrfLogSig }),
+    { expirationTtl: 365 * 24 * 3600 * 10 },
+  );
 
   return json({ bundle_id: bundleId, rrn, transparency_log_index: next }, 201);
 }

--- a/functions/v2/compliance-bundle/index.test.ts
+++ b/functions/v2/compliance-bundle/index.test.ts
@@ -1,0 +1,61 @@
+// functions/v2/compliance-bundle/index.test.ts
+import { describe, it, expect, vi } from "vitest";
+import { onRequestPost } from "./index.js";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    env: {
+      RRF_KV: {
+        get: vi.fn(async (k: string) => store[k] ?? null),
+        put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+        list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+          keys: Object.keys(store).filter(k => k.startsWith(prefix)).map(name => ({ name })),
+          list_complete: true,
+        })),
+        delete: vi.fn(),
+      } as unknown as KVNamespace,
+    },
+    store,
+  };
+}
+
+function mkReq(body: unknown): Request {
+  return new Request("https://x/v2/compliance-bundle", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /v2/compliance-bundle", () => {
+  it("returns 400 on invalid JSON body", async () => {
+    const { env } = makeEnv();
+    const req = new Request("https://x/v2/compliance-bundle", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not json",
+    });
+    const res = await onRequestPost({ env, request: req } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when schema_version is missing", async () => {
+    const { env } = makeEnv();
+    const res = await onRequestPost({ env, request: mkReq({ rrn: "RRN-000000000002" }) } as any);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 415 on unsupported schema_version", async () => {
+    const { env } = makeEnv();
+    const res = await onRequestPost({
+      env,
+      request: mkReq({ schema_version: "9.99", rrn: "RRN-000000000002" }),
+    } as any);
+    expect(res.status).toBe(415);
+  });
+
+  // Happy-path 201 + 409 idempotency + 403 (kid not registered, scope missing)
+  // are covered by the smoke test in Task 14, which mints real keys and
+  // exercises the full flow including handlers/v10.
+});

--- a/functions/v2/compliance-bundle/index.ts
+++ b/functions/v2/compliance-bundle/index.ts
@@ -1,0 +1,49 @@
+/**
+ * /v2/compliance-bundle
+ *
+ * POST: schema-version routing -> handlers/v10 (or 415 on unsupported version).
+ * GET /v2/compliance-bundle/{bundle_id}: full payload, Bearer-gated via M2M_TRUSTED JWT.
+ *
+ * Note: GET-by-id is handled by [bundle_id]/index.ts (separate file, Cloudflare
+ * Pages Functions path-param convention). This file only handles the bare
+ * /v2/compliance-bundle path (POST).
+ */
+
+import { handleV10 } from "./handlers/v10.js";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+  RRF_ROOT_PUBKEY?: string;
+}
+
+const SCHEMA_VERSION_HANDLERS: Record<string, (p: Record<string, unknown>, env: Env) => Promise<Response>> = {
+  "1.0": handleV10,
+};
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: "invalid JSON body" }, 400);
+  }
+
+  const schemaVersion = payload["schema_version"];
+  if (typeof schemaVersion !== "string") {
+    return json({ error: "schema_version required" }, 400);
+  }
+  const handler = SCHEMA_VERSION_HANDLERS[schemaVersion];
+  if (!handler) {
+    return json({
+      error: `Unsupported schema_version: ${schemaVersion} (supported: ${Object.keys(SCHEMA_VERSION_HANDLERS).join(", ")})`,
+    }, 415);
+  }
+  return handler(payload, env);
+};

--- a/scripts/init-rrf-log-signing-key.ts
+++ b/scripts/init-rrf-log-signing-key.ts
@@ -3,10 +3,13 @@
  * One-time bootstrap: mint the RRF root signing keypair (Ed25519),
  * write priv to rrf:root:privkey, write pub to rrf:root:pubkey.
  *
- * Idempotent: skips if rrf:root:privkey already exists.
+ * NOT IDEMPOTENT: every run mints a fresh keypair. Re-running after
+ * production bootstrap overwrites the root key, breaking ALL prior
+ * M2M_TRUSTED JWTs (instant invalidation) and ALL prior compliance-bundle
+ * proof verifications (rrf_log_signature continuity broken). The operator
+ * MUST precheck before piping output to wrangler:
  *
- * Usage:
- *   wrangler kv:key get --binding RRF_KV "rrf:root:privkey"  # check first
+ *   wrangler kv:key get --binding RRF_KV "rrf:root:privkey"  # MUST be empty
  *   tsx scripts/init-rrf-log-signing-key.ts | wrangler kv:bulk put --binding RRF_KV
  */
 

--- a/scripts/init-rrf-log-signing-key.ts
+++ b/scripts/init-rrf-log-signing-key.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env tsx
+/**
+ * One-time bootstrap: mint the RRF root signing keypair (Ed25519),
+ * write priv to rrf:root:privkey, write pub to rrf:root:pubkey.
+ *
+ * Idempotent: skips if rrf:root:privkey already exists.
+ *
+ * Usage:
+ *   wrangler kv:key get --binding RRF_KV "rrf:root:privkey"  # check first
+ *   tsx scripts/init-rrf-log-signing-key.ts | wrangler kv:bulk put --binding RRF_KV
+ */
+
+import { writeFileSync } from "node:fs";
+
+async function main() {
+  const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+  const privDer = await crypto.subtle.exportKey("pkcs8", (kp as CryptoKeyPair).privateKey);
+  const pubDer = await crypto.subtle.exportKey("spki", (kp as CryptoKeyPair).publicKey);
+  const b64 = (b: ArrayBuffer) => btoa(String.fromCharCode(...new Uint8Array(b)));
+  const privB64 = b64(privDer);
+  const pubB64 = b64(pubDer);
+  const pubPem = `-----BEGIN PUBLIC KEY-----\n${pubB64}\n-----END PUBLIC KEY-----\n`;
+
+  const bulkInput = [
+    { key: "rrf:root:privkey", value: privB64 },
+    { key: "rrf:root:pubkey", value: pubPem },
+  ];
+
+  // Print to stdout for piping to wrangler kv:bulk put.
+  process.stdout.write(JSON.stringify(bulkInput, null, 2));
+
+  // Also save the privkey locally for offline backup (encrypted in 1Password
+  // post-bootstrap; delete the local file once archived).
+  writeFileSync("/tmp/rrf-root-privkey.b64", privB64, { mode: 0o600 });
+  process.stderr.write("\nLocal backup written to /tmp/rrf-root-privkey.b64 (mode 0600).\n");
+  process.stderr.write("Archive to 1Password and DELETE the local file.\n");
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/scripts/register-aggregator-kid.ts
+++ b/scripts/register-aggregator-kid.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env tsx
+/**
+ * One-time idempotent: write the kid -> RAN mapping at
+ *   kid:<kid>:<registered_at>
+ *
+ * Usage (read REGIST args from CLI):
+ *   tsx scripts/register-aggregator-kid.ts \
+ *     --kid ops-aggregator-2026-05 \
+ *     --ran RAN-000000000001 \
+ *     --valid-from 2026-05-04T00:00:00Z \
+ *     [--valid-until 2027-05-04T00:00:00Z] \
+ *     --registered-by RAN-000000000001 \
+ *     | wrangler kv:bulk put --binding RRF_KV
+ */
+
+function arg(name: string, required = true): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) {
+    if (required) {
+      console.error(`Missing --${name}`);
+      process.exit(2);
+    }
+    return undefined;
+  }
+  return process.argv[idx + 1];
+}
+
+const kid = arg("kid")!;
+const ran = arg("ran")!;
+const validFrom = arg("valid-from")!;
+const validUntil = arg("valid-until", false);
+const registeredBy = arg("registered-by")!;
+const registeredAt = new Date().toISOString();
+
+const mapping: Record<string, unknown> = {
+  ran,
+  valid_from: validFrom,
+  registered_at: registeredAt,
+  registered_by: registeredBy,
+};
+if (validUntil) mapping["valid_until"] = validUntil;
+
+const bulkInput = [{
+  key: `kid:${kid}:${registeredAt}`,
+  value: JSON.stringify(mapping),
+}];
+
+process.stdout.write(JSON.stringify(bulkInput, null, 2));

--- a/scripts/register-aggregator-scope.ts
+++ b/scripts/register-aggregator-scope.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env tsx
+/**
+ * One-time idempotent: write the aggregator -> RRN scope mapping at
+ *   aggregator-scope:RAN-NNN/RRN-MMM
+ *
+ * Usage:
+ *   tsx scripts/register-aggregator-scope.ts \
+ *     --aggregator-ran RAN-000000000001 \
+ *     --robot-rrn RRN-000000000002 \
+ *     --authorized-by RAN-000000000001 \
+ *     [--valid-until 2027-05-04T00:00:00Z] \
+ *     | wrangler kv:bulk put --binding RRF_KV
+ */
+
+function arg(name: string, required = true): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) {
+    if (required) { console.error(`Missing --${name}`); process.exit(2); }
+    return undefined;
+  }
+  return process.argv[idx + 1];
+}
+
+const aggregatorRan = arg("aggregator-ran")!;
+const robotRrn = arg("robot-rrn")!;
+const authorizedBy = arg("authorized-by")!;
+const validUntil = arg("valid-until", false);
+
+const scope: Record<string, unknown> = {
+  ran: aggregatorRan,
+  rrn: robotRrn,
+  authorized_at: new Date().toISOString(),
+  authorized_by: authorizedBy,
+};
+if (validUntil) scope["valid_until"] = validUntil;
+
+const bulkInput = [{
+  key: `aggregator-scope:${aggregatorRan}/${robotRrn}`,
+  value: JSON.stringify(scope),
+}];
+
+process.stdout.write(JSON.stringify(bulkInput, null, 2));

--- a/tests/compliance-intake.smoke.test.ts
+++ b/tests/compliance-intake.smoke.test.ts
@@ -2,11 +2,16 @@ import { describe, it, expect, vi } from "vitest";
 import {
   buildSafetyBenchmark, buildIfu, buildIncidentReport, buildEuRegisterEntry,
   SAFETY_BENCHMARK_SCHEMA, IFU_SCHEMA, INCIDENT_REPORT_SCHEMA, EU_REGISTER_SCHEMA,
+  canonicalJson, signMlDsa,
 } from "rcan-ts";
+import { ed25519 } from "@noble/curves/ed25519.js";
 import { onRequest as sbHandler } from "../functions/v2/robots/[rrn]/safety-benchmark.js";
 import { onRequest as ifuHandler } from "../functions/v2/robots/[rrn]/ifu.js";
 import { onRequest as friaHandler } from "../functions/v2/robots/[rrn]/fria.js";
 import { onRequest as incHandler } from "../functions/v2/robots/[rrn]/incident-report.js";
+import { onRequestPost as bundlePostHandler } from "../functions/v2/compliance-bundle/index.js";
+import { onRequestGet as bundleProofHandler } from "../functions/v2/compliance-bundle/[bundle_id]/proof.js";
+import { onRequestGet as bundleFullHandler } from "../functions/v2/compliance-bundle/[bundle_id]/index.js";
 import { signComplianceBody, makeTestKeypair, makeRobotRecord } from "../functions/v2/_lib/test-helpers.js";
 
 const RRN = "RRN-000000000001";
@@ -141,5 +146,197 @@ describe("compliance intake end-to-end smoke", () => {
       expect(retrieved.rmn).toBe(RMN);
       expect(retrieved._submitted_by_rrn).toBe(RRN);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /v2/compliance-bundle round-trip (Plan 4 Task 14)
+//
+// Independent describe block (separate from §22-26 smoke). Exercises the full
+// hybrid-signed bundle intake: POST 201, POST again 409, GET /proof unauth
+// 200, GET full no-auth 401, GET full with M2M_TRUSTED JWT 200.
+//
+// Hybrid sign manually (canonicalJson + ed25519.sign + signMlDsa) to mirror
+// what opencastor-ops Phase A `_Signer` produces. Using rcan-ts.signBody would
+// inject pq_signing_pub + pq_kid into the canonical bytes that the Phase A
+// aggregator (and Task 8 verifier) do NOT include — third deviation in this
+// branch, after Tasks 6 and 8.
+// ---------------------------------------------------------------------------
+
+function makeBundleEnv() {
+  const store: Record<string, string> = {};
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+      list: vi.fn(async ({ prefix }: { prefix: string; cursor?: string }) => {
+        // Single-page mock — sufficient for tests that create 1-2 bundles.
+        const keys = Object.keys(store)
+          .filter(k => k.startsWith(prefix))
+          .map(name => ({ name }));
+        return { keys, list_complete: true, cursor: undefined };
+      }),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+    __store: store,
+  };
+}
+
+describe("compliance-bundle intake end-to-end smoke", () => {
+  it("rounds-trips a hybrid-signed bundle through POST + GET-full + GET-proof", async () => {
+    const kp = await makeTestKeypair();
+    const env = makeBundleEnv();
+    const b64 = (b: Uint8Array) => btoa(String.fromCharCode(...b));
+
+    // 1. Pre-populate KV: authority record (carries the verifier's trust anchors).
+    const RAN = "RAN-000000000001";
+    const BUNDLE_RRN = "RRN-000000000002";
+    const KID = "ops-aggregator-test";
+    env.__store[`authority:${RAN}`] = JSON.stringify({
+      ran: RAN,
+      organization: "OpenCastor Ops",
+      signing_pub: b64(kp.ed25519Public),
+      pq_signing_pub: b64(kp.mlDsa.publicKey),
+    });
+    env.__store[`kid:${KID}:2026-01-01T00:00:00Z`] = JSON.stringify({
+      ran: RAN,
+      valid_from: "2026-01-01T00:00:00Z",
+      registered_at: "2026-01-01T00:00:00Z",
+      registered_by: RAN,
+    });
+    env.__store[`aggregator-scope:${RAN}/${BUNDLE_RRN}`] = JSON.stringify({
+      ran: RAN, rrn: BUNDLE_RRN,
+      authorized_at: "2026-01-01T00:00:00Z",
+      authorized_by: RAN,
+    });
+
+    // 2. RRF root keypair (mint inline; for proof signing + JWT verify).
+    const rrfKp = await crypto.subtle.generateKey(
+      { name: "Ed25519" }, true, ["sign", "verify"],
+    ) as CryptoKeyPair;
+    const rrfPrivDer = await crypto.subtle.exportKey("pkcs8", rrfKp.privateKey);
+    const rrfPubDer = await crypto.subtle.exportKey("spki", rrfKp.publicKey);
+    const bufB64 = (buf: ArrayBuffer) =>
+      btoa(String.fromCharCode(...new Uint8Array(buf)));
+    env.__store["rrf:root:privkey"] = bufB64(rrfPrivDer);
+    env.__store["rrf:root:pubkey"] =
+      `-----BEGIN PUBLIC KEY-----\n${bufB64(rrfPubDer)}\n-----END PUBLIC KEY-----\n`;
+
+    // 3. Build the bundle (without bundle_signature). Sign canonical bytes.
+    const bundleId = "bundle_smoke_test_001";
+    const bundle: Record<string, unknown> = {
+      schema_version: "1.0",
+      bundle_id: bundleId,
+      rrn: BUNDLE_RRN,
+      signed_at: "2026-05-04T12:00:00Z",
+      robot_md_sha256: "deadbeef",
+      matrix_version: "1.0",
+      artifacts: [
+        { artifact_type: "cert-gateway-authority", payload: {} },
+        { artifact_type: "eu-act-fria", payload: {} },
+        { artifact_type: "version-matrix-snapshot", payload: {} },
+      ],
+    };
+    const canon = canonicalJson(bundle);
+    const ed25519Sig = ed25519.sign(canon, kp.ed25519Secret);
+    const mlDsaSig = signMlDsa(kp.mlDsa.privateKey, canon);
+    bundle["bundle_signature"] = {
+      kid: KID,
+      alg: ["Ed25519", "ML-DSA-65"],
+      sig: {
+        ed25519: b64(ed25519Sig),
+        ml_dsa: b64(mlDsaSig),
+        ed25519_pub: b64(kp.ed25519Public),
+      },
+    };
+
+    // 4. POST -> 201.
+    const postRes = await bundlePostHandler({
+      env, request: new Request("https://x/v2/compliance-bundle", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(bundle),
+      }),
+    } as any);
+    if (postRes.status !== 201) {
+      const errBody = await postRes.text();
+      throw new Error(`Expected 201, got ${postRes.status}: ${errBody}`);
+    }
+    const postBody = await postRes.json() as any;
+    expect(postBody.bundle_id).toBe(bundleId);
+    expect(postBody.rrn).toBe(BUNDLE_RRN);
+    expect(typeof postBody.transparency_log_index).toBe("number");
+
+    // 5. POST again -> 409.
+    const dupRes = await bundlePostHandler({
+      env, request: new Request("https://x/v2/compliance-bundle", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(bundle),
+      }),
+    } as any);
+    expect(dupRes.status).toBe(409);
+
+    // 6. GET /proof unauthenticated -> 200, returns rrf_log_signature.
+    const proofRes = await bundleProofHandler({
+      env, request: new Request(`https://x/v2/compliance-bundle/${bundleId}/proof`),
+      params: { bundle_id: bundleId },
+    } as any);
+    expect(proofRes.status).toBe(200);
+    const proof = await proofRes.json() as any;
+    expect(proof.bundle_id).toBe(bundleId);
+    expect(proof.rrf_log_signature).toBeDefined();
+    expect(proof.rrf_log_signature.kid).toBe("rrf-root");
+
+    // 7. GET full WITHOUT JWT -> 401.
+    const noAuthRes = await bundleFullHandler({
+      env, request: new Request(`https://x/v2/compliance-bundle/${bundleId}`),
+      params: { bundle_id: bundleId },
+    } as any);
+    expect(noAuthRes.status).toBe(401);
+
+    // 8. Mint M2M_TRUSTED JWT (matches the production mint at
+    //    functions/v2/orchestrators/[id]/token.ts:80-110).
+    //    Signing input = b64u(header).b64u(payload-MINUS-rrf_sig); the emitted
+    //    JWT's parts[1] embeds rrf_sig back. jwt-verify reconstructs by
+    //    stripping rrf_sig before recomputing the signing input.
+    const jwtHeader = { alg: "EdDSA", typ: "JWT" };
+    const jwtPayloadCore = {
+      sub: "test-orch",
+      iss: "rrf.rcan.dev",
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      rcan_role: "m2m_trusted",
+      rcan_scopes: ["fleet.trusted"],
+      fleet_rrns: [BUNDLE_RRN],
+    };
+    const b64url = (s: string) =>
+      btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    const signingInput =
+      `${b64url(JSON.stringify(jwtHeader))}.${b64url(JSON.stringify(jwtPayloadCore))}`;
+    const enc = new TextEncoder();
+    const sigBuf = await crypto.subtle.sign(
+      "Ed25519", rrfKp.privateKey, enc.encode(signingInput),
+    );
+    const jwtSig = btoa(String.fromCharCode(...new Uint8Array(sigBuf)))
+      .replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+    const jwtPayloadWithSig = { ...jwtPayloadCore, rrf_sig: jwtSig };
+    const jwt =
+      `${b64url(JSON.stringify(jwtHeader))}.${b64url(JSON.stringify(jwtPayloadWithSig))}.${jwtSig}`;
+
+    // 9. GET full WITH JWT -> 200, returns full payload incl artifacts.
+    const authRes = await bundleFullHandler({
+      env, request: new Request(`https://x/v2/compliance-bundle/${bundleId}`, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      }),
+      params: { bundle_id: bundleId },
+    } as any);
+    if (authRes.status !== 200) {
+      const errBody = await authRes.text();
+      throw new Error(
+        `Expected GET-full 200 with JWT, got ${authRes.status}: ${errBody}`,
+      );
+    }
+    const fullBundle = await authRes.json() as any;
+    expect(fullBundle.bundle_id).toBe(bundleId);
+    expect(fullBundle.artifacts).toHaveLength(3);
   });
 });


### PR DESCRIPTION
Cross-repo Plan 4 Phase 3 RRF half. Spec at `opencastor-ops/docs/superpowers/specs/2026-05-04-compliance-bundle-intake-design.md`. Plan at `opencastor-ops/docs/superpowers/plans/2026-05-04-compliance-bundle-intake.md`.

opencastor-ops aggregator hybrid-sig upgrade (Phase A) already landed on opencastor-ops master at `7b61ef1`.

## Adds

- POST `/v2/compliance-bundle` with hybrid (Ed25519 + ML-DSA-65) sig verify + aggregator-scope authz check + idempotency (409) + RRF-root-signed transparency log entry
- GET `/v2/compliance-bundle/{id}` (Bearer-gated full payload via M2M_TRUSTED JWT)
- GET `/v2/compliance-bundle/{id}/proof` (public metadata-only, RRF-root-signed; verifiable offline against `/.well-known/rrf-root-pubkey.pem`)
- 6 `_lib` helpers: kid-resolve (validity windows), aggregator-scope, jwt-verify (Web Crypto Ed25519 SPKI), rrf-log-sign, verify-bundle-hybrid (+ types)
- 3 registration scripts: init-rrf-log-signing-key, register-aggregator-kid, register-aggregator-scope
- Schema-version routing (`SCHEMA_VERSION_HANDLERS = {"1.0": handleV10}`) — additive future migration
- vitest unit + smoke coverage (route tests + end-to-end round-trip)

## Authorized spec deviations (3)

1. **Task 6 jwt-verify**: `rcan-ts.verifyM2mTrustedToken` does NOT verify signatures; uses Web Crypto Ed25519 SPKI verify directly. Documented in commit body + file docstring.
2. **Task 8 verify-bundle-hybrid**: `rcan-ts.verifyBody` requires `pq_signing_pub` field absent from aggregator output, and would canonicalJson different bytes than what was signed. Uses `verifyHybrid` primitive directly.
3. **Task 14 smoke**: `rcan-ts.signBody` injects `pq_signing_pub` + `pq_kid` before signing, breaking byte-parity with the verifier. Test signs manually via primitives.

All three preserve the spec's design intent; documented in commit messages.

## Refs

- Spec: `opencastor-ops/docs/superpowers/specs/2026-05-04-compliance-bundle-intake-design.md`
- Plan: `opencastor-ops/docs/superpowers/plans/2026-05-04-compliance-bundle-intake.md`
- Phase A (opencastor-ops): merged to master at `7b61ef1`