### PR TITLE
feat(api): /v2/cert-intake (Plan 6 Phase 4)

### DIFF
--- a/functions/v2/_lib/cert-rig-resolve.test.ts
+++ b/functions/v2/_lib/cert-rig-resolve.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveRigKid } from "./cert-rig-resolve.js";
+import type { RigKidMapping } from "./types.js";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(),
+      list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+        keys: Object.keys(store).filter(k => k.startsWith(prefix)).map(name => ({ name })),
+        list_complete: true,
+      })),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+  };
+}
+
+const baseMapping = (overrides: Partial<RigKidMapping> = {}): RigKidMapping => ({
+  rig_id: "bob",
+  rrn: "RRN-000000000002",
+  signing_pub: "htSRgObFeBjjB6JIBW9XlNfivlVbQwFJcKWn+n0flvg=",
+  valid_from: "2026-05-04T00:00:00Z",
+  registered_at: "2026-05-04T00:00:00Z",
+  ...overrides,
+});
+
+describe("resolveRigKid", () => {
+  it("returns the registered mapping when ran_at falls within validity window", async () => {
+    const env = makeEnv({
+      "cert-rig:bob-rig-2026:2026-05-04T00:00:00Z": JSON.stringify(baseMapping()),
+    });
+    const result = await resolveRigKid(env, "bob-rig-2026", "2026-06-01T00:00:00Z");
+    expect(result?.rrn).toBe("RRN-000000000002");
+    expect(result?.signing_pub).toBe("htSRgObFeBjjB6JIBW9XlNfivlVbQwFJcKWn+n0flvg=");
+  });
+
+  it("returns null when kid is not registered", async () => {
+    const env = makeEnv({});
+    const result = await resolveRigKid(env, "nonexistent-kid", "2026-06-01T00:00:00Z");
+    expect(result).toBeNull();
+  });
+
+  it("excludes mappings whose valid_until has passed", async () => {
+    const env = makeEnv({
+      "cert-rig:bob-rig-2026:2026-05-04T00:00:00Z": JSON.stringify(baseMapping({
+        valid_until: "2026-05-10T00:00:00Z",
+      })),
+    });
+    const result = await resolveRigKid(env, "bob-rig-2026", "2026-06-01T00:00:00Z");
+    expect(result).toBeNull();
+  });
+
+  it("picks the most-recent registered_at when multiple mappings are valid (rotation overlap)", async () => {
+    const env = makeEnv({
+      "cert-rig:bob-rig-2026:2026-05-04T00:00:00Z": JSON.stringify(baseMapping({
+        rrn: "RRN-000000000002",
+      })),
+      "cert-rig:bob-rig-2026:2026-05-15T00:00:00Z": JSON.stringify(baseMapping({
+        rrn: "RRN-000000000999",
+        registered_at: "2026-05-15T00:00:00Z",
+      })),
+    });
+    const result = await resolveRigKid(env, "bob-rig-2026", "2026-06-01T00:00:00Z");
+    expect(result?.rrn).toBe("RRN-000000000999");
+  });
+});

--- a/functions/v2/_lib/cert-rig-resolve.ts
+++ b/functions/v2/_lib/cert-rig-resolve.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolve a cert-intake rig_signature.kid to the registered rig record,
+ * filtered by `ran_at` falling within the kid's validity window.
+ *
+ * KV layout:
+ *   cert-rig:<kid>:<registered_at> -> RigKidMapping (versioned per registration)
+ *
+ * If multiple cert-rig:<kid>:* entries are valid for the ran_at, the resolver
+ * picks the most-recent registered_at (defensive against operator error during
+ * rotation). Mirrors kid-resolve.ts (Plan 4 Phase 3) shape.
+ */
+
+import type { RigKidMapping } from "./types.js";
+
+export async function resolveRigKid(
+  env: { RRF_KV: KVNamespace },
+  kid: string,
+  ranAtIso: string,
+): Promise<RigKidMapping | null> {
+  const list = await env.RRF_KV.list({ prefix: `cert-rig:${kid}:` });
+  if (list.keys.length === 0) return null;
+
+  const ranAtMs = Date.parse(ranAtIso);
+  if (Number.isNaN(ranAtMs)) return null;
+
+  type Candidate = { mapping: RigKidMapping; key: string };
+  const candidates: Candidate[] = [];
+  for (const k of list.keys) {
+    const raw = await env.RRF_KV.get(k.name, "text");
+    if (!raw) continue;
+    let mapping: RigKidMapping;
+    try { mapping = JSON.parse(raw) as RigKidMapping; }
+    catch { continue; }
+    const fromMs = Date.parse(mapping.valid_from);
+    const untilMs = mapping.valid_until ? Date.parse(mapping.valid_until) : Number.POSITIVE_INFINITY;
+    if (Number.isNaN(fromMs)) continue;
+    if (ranAtMs < fromMs) continue;
+    if (ranAtMs >= untilMs) continue;
+    candidates.push({ mapping, key: k.name });
+  }
+  if (candidates.length === 0) return null;
+  // Pick the most-recent registered_at (lexicographic on ISO-8601 = chronological).
+  candidates.sort((a, b) => b.mapping.registered_at.localeCompare(a.mapping.registered_at));
+  return candidates[0].mapping;
+}

--- a/functions/v2/_lib/cert-witness-resolve.test.ts
+++ b/functions/v2/_lib/cert-witness-resolve.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveWitnessKid } from "./cert-witness-resolve.js";
+import type { WitnessKidMapping } from "./types.js";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(),
+      list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+        keys: Object.keys(store).filter(k => k.startsWith(prefix)).map(name => ({ name })),
+        list_complete: true,
+      })),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+  };
+}
+
+const baseMapping = (overrides: Partial<WitnessKidMapping> = {}): WitnessKidMapping => ({
+  witness_id: "craigm",
+  rig_id: "bob",
+  signing_pub: "PeTWtnHxB5YhnZRPrbuLkgO5CI3PcaYO//zpUh4Nv6M=",
+  valid_from: "2026-05-04T00:00:00Z",
+  registered_at: "2026-05-04T00:00:00Z",
+  ...overrides,
+});
+
+describe("resolveWitnessKid", () => {
+  it("returns the registered mapping when ran_at falls within validity window", async () => {
+    const env = makeEnv({
+      "cert-witness:witness-bob-craigm:2026-05-04T00:00:00Z": JSON.stringify(baseMapping()),
+    });
+    const result = await resolveWitnessKid(env, "witness-bob-craigm", "2026-06-01T00:00:00Z");
+    expect(result?.witness_id).toBe("craigm");
+    expect(result?.rig_id).toBe("bob");
+  });
+
+  it("returns null when kid is not registered", async () => {
+    const env = makeEnv({});
+    const result = await resolveWitnessKid(env, "nonexistent-witness", "2026-06-01T00:00:00Z");
+    expect(result).toBeNull();
+  });
+
+  it("excludes mappings whose valid_until has passed", async () => {
+    const env = makeEnv({
+      "cert-witness:witness-bob-craigm:2026-05-04T00:00:00Z": JSON.stringify(baseMapping({
+        valid_until: "2026-05-10T00:00:00Z",
+      })),
+    });
+    const result = await resolveWitnessKid(env, "witness-bob-craigm", "2026-06-01T00:00:00Z");
+    expect(result).toBeNull();
+  });
+
+  it("picks the most-recent registered_at on rotation overlap", async () => {
+    const env = makeEnv({
+      "cert-witness:witness-bob-craigm:2026-05-04T00:00:00Z": JSON.stringify(baseMapping({
+        witness_id: "craigm-old",
+      })),
+      "cert-witness:witness-bob-craigm:2026-05-15T00:00:00Z": JSON.stringify(baseMapping({
+        witness_id: "craigm-new",
+        registered_at: "2026-05-15T00:00:00Z",
+      })),
+    });
+    const result = await resolveWitnessKid(env, "witness-bob-craigm", "2026-06-01T00:00:00Z");
+    expect(result?.witness_id).toBe("craigm-new");
+  });
+});

--- a/functions/v2/_lib/cert-witness-resolve.ts
+++ b/functions/v2/_lib/cert-witness-resolve.ts
@@ -1,0 +1,44 @@
+/**
+ * Resolve a cert-intake witness_signature.kid to the registered witness record,
+ * filtered by `ran_at` falling within the kid's validity window.
+ *
+ * KV layout:
+ *   cert-witness:<kid>:<registered_at> -> WitnessKidMapping
+ *
+ * Rotation overlap: most-recent registered_at wins.
+ * Mirrors cert-rig-resolve.ts (Plan 6 Phase 4 Task 2) shape.
+ */
+
+import type { WitnessKidMapping } from "./types.js";
+
+export async function resolveWitnessKid(
+  env: { RRF_KV: KVNamespace },
+  kid: string,
+  ranAtIso: string,
+): Promise<WitnessKidMapping | null> {
+  const list = await env.RRF_KV.list({ prefix: `cert-witness:${kid}:` });
+  if (list.keys.length === 0) return null;
+
+  const ranAtMs = Date.parse(ranAtIso);
+  if (Number.isNaN(ranAtMs)) return null;
+
+  type Candidate = { mapping: WitnessKidMapping; key: string };
+  const candidates: Candidate[] = [];
+  for (const k of list.keys) {
+    const raw = await env.RRF_KV.get(k.name, "text");
+    if (!raw) continue;
+    let mapping: WitnessKidMapping;
+    try { mapping = JSON.parse(raw) as WitnessKidMapping; }
+    catch { continue; }
+    const fromMs = Date.parse(mapping.valid_from);
+    const untilMs = mapping.valid_until ? Date.parse(mapping.valid_until) : Number.POSITIVE_INFINITY;
+    if (Number.isNaN(fromMs)) continue;
+    if (ranAtMs < fromMs) continue;
+    if (ranAtMs >= untilMs) continue;
+    candidates.push({ mapping, key: k.name });
+  }
+  if (candidates.length === 0) return null;
+  // Pick the most-recent registered_at (lexicographic on ISO-8601 = chronological).
+  candidates.sort((a, b) => b.mapping.registered_at.localeCompare(a.mapping.registered_at));
+  return candidates[0].mapping;
+}

--- a/functions/v2/_lib/types.ts
+++ b/functions/v2/_lib/types.ts
@@ -202,3 +202,41 @@ export type ComplianceBundleEntry = {
 export type ComplianceBundleProof = Omit<ComplianceBundleEntry, never>;
 // proof IS the entry — same fields, served at /v2/compliance-bundle/{id}/proof
 // without the artifact bodies.
+
+// === Cert intake — Plan 6 Phase 4 (Track-3 HIL property evidence) ===
+
+export type RigKidMapping = {
+  rig_id: string;             // e.g. "bob"
+  rrn: `RRN-${string}`;        // the robot this rig hosts
+  signing_pub: string;         // Ed25519 base64
+  valid_from: string;          // ISO-8601 UTC
+  valid_until?: string;        // ISO-8601 UTC; absent = currently active
+  registered_at: string;       // ISO-8601 UTC
+  registered_by?: `RAN-${string}`;
+};
+
+export type WitnessKidMapping = {
+  witness_id: string;          // e.g. "craigm"
+  rig_id: string;              // pairing — the rig this witness co-signs for
+  signing_pub: string;         // Ed25519 base64
+  valid_from: string;
+  valid_until?: string;
+  registered_at: string;
+  registered_by?: `RAN-${string}`;
+};
+
+export type CertIntakeEntry = {
+  cert_id: string;             // "cert_<sha256-32hex>"
+  rrn: `RRN-${string}`;
+  property_id: string;          // "SF-001" | "SF-002" | "GW-001" | future
+  schema_version: string;
+  rig_id: string;
+  ran_at: number;
+  all_pass: boolean;
+  iterations: number;
+  transparency_log_index: number;
+  logged_at: string;            // ISO-8601 server-side
+  rig_signature:     { kid: string; alg: "Ed25519"; sig: string };
+  witness_signature: { kid: string; alg: "Ed25519"; sig: string };
+  rrf_log_signature: { kid: string; alg: "Ed25519"; sig: string };
+};

--- a/functions/v2/_lib/verify-hil-evidence.test.ts
+++ b/functions/v2/_lib/verify-hil-evidence.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from "vitest";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { canonicalJson } from "rcan-ts";
+import { verifyHilEvidence } from "./verify-hil-evidence.js";
+
+function b64(u8: Uint8Array): string {
+  return Buffer.from(u8).toString("base64");
+}
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(),
+      list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+        keys: Object.keys(store).filter(k => k.startsWith(prefix)).map(name => ({ name })),
+        list_complete: true,
+      })),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+  };
+}
+
+function makeBody(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: "1.0",
+    property_id: "SF-001",
+    rig: "bob",
+    robot_class: "so-arm101",
+    ran_at: 1777939200.0, // 2026-05-05T00:00:00Z — after valid_from 2026-05-04
+    iterations: 10,
+    results: [{ iteration: 1, latency_ms: 47, pass: true }],
+    all_pass: true,
+    ...overrides,
+  };
+}
+
+function signAndAttach(body: Record<string, unknown>, rigPriv: Uint8Array, witnessPriv: Uint8Array, rigKid: string, witnessKid: string) {
+  const core = { ...body };
+  delete (core as { rig_signature?: unknown }).rig_signature;
+  delete (core as { witness_signature?: unknown }).witness_signature;
+  const msg = new TextEncoder().encode(canonicalJson(core));
+  const rigSig = ed25519.sign(msg, rigPriv);
+  const witnessSig = ed25519.sign(msg, witnessPriv);
+  return {
+    ...body,
+    rig_signature: { kid: rigKid, alg: "Ed25519", sig: b64(rigSig) },
+    witness_signature: { kid: witnessKid, alg: "Ed25519", sig: b64(witnessSig) },
+  };
+}
+
+describe("verifyHilEvidence", () => {
+  it("returns ok with rig + witness records on a fresh, well-formed body", async () => {
+    const rigPriv = crypto.getRandomValues(new Uint8Array(32));
+    const rigPub = ed25519.getPublicKey(rigPriv);
+    const witnessPriv = crypto.getRandomValues(new Uint8Array(32));
+    const witnessPub = ed25519.getPublicKey(witnessPriv);
+    const env = makeEnv({
+      "cert-rig:bob-rig-2026:2026-05-04T00:00:00Z": JSON.stringify({
+        rig_id: "bob",
+        rrn: "RRN-000000000002",
+        signing_pub: b64(rigPub),
+        valid_from: "2026-05-04T00:00:00Z",
+        registered_at: "2026-05-04T00:00:00Z",
+      }),
+      "cert-witness:witness-bob-craigm:2026-05-04T00:00:00Z": JSON.stringify({
+        witness_id: "craigm",
+        rig_id: "bob",
+        signing_pub: b64(witnessPub),
+        valid_from: "2026-05-04T00:00:00Z",
+        registered_at: "2026-05-04T00:00:00Z",
+      }),
+    });
+    const body = signAndAttach(makeBody(), rigPriv, witnessPriv, "bob-rig-2026", "witness-bob-craigm");
+    const result = await verifyHilEvidence(env, body);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.rig.rrn).toBe("RRN-000000000002");
+      expect(result.witness.rig_id).toBe("bob");
+    }
+  });
+
+  it("returns ok=false 403 when rig kid is not registered", async () => {
+    const env = makeEnv({});
+    const body = makeBody({
+      rig_signature: { kid: "ghost", alg: "Ed25519", sig: "AA==" },
+      witness_signature: { kid: "ghost-witness", alg: "Ed25519", sig: "AA==" },
+    });
+    const result = await verifyHilEvidence(env, body);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+      expect(result.error).toMatch(/rig.*kid.*not.*registered/i);
+    }
+  });
+
+  it("returns ok=false 401 when rig sig does not verify", async () => {
+    const rigPriv = crypto.getRandomValues(new Uint8Array(32));
+    const witnessPriv = crypto.getRandomValues(new Uint8Array(32));
+    const witnessPub = ed25519.getPublicKey(witnessPriv);
+    // Register rig with a *different* pub than the one signing.
+    const otherPub = ed25519.getPublicKey(crypto.getRandomValues(new Uint8Array(32)));
+    const env = makeEnv({
+      "cert-rig:bob-rig-2026:2026-05-04T00:00:00Z": JSON.stringify({
+        rig_id: "bob",
+        rrn: "RRN-000000000002",
+        signing_pub: b64(otherPub),
+        valid_from: "2026-05-04T00:00:00Z",
+        registered_at: "2026-05-04T00:00:00Z",
+      }),
+      "cert-witness:witness-bob-craigm:2026-05-04T00:00:00Z": JSON.stringify({
+        witness_id: "craigm",
+        rig_id: "bob",
+        signing_pub: b64(witnessPub),
+        valid_from: "2026-05-04T00:00:00Z",
+        registered_at: "2026-05-04T00:00:00Z",
+      }),
+    });
+    const body = signAndAttach(makeBody(), rigPriv, witnessPriv, "bob-rig-2026", "witness-bob-craigm");
+    const result = await verifyHilEvidence(env, body);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+      expect(result.error).toMatch(/rig.*signature/i);
+    }
+  });
+
+  it("returns ok=false 403 when witness.rig_id does not match rig.rig_id (scope mismatch)", async () => {
+    const rigPriv = crypto.getRandomValues(new Uint8Array(32));
+    const rigPub = ed25519.getPublicKey(rigPriv);
+    const witnessPriv = crypto.getRandomValues(new Uint8Array(32));
+    const witnessPub = ed25519.getPublicKey(witnessPriv);
+    const env = makeEnv({
+      "cert-rig:bob-rig-2026:2026-05-04T00:00:00Z": JSON.stringify({
+        rig_id: "bob",
+        rrn: "RRN-000000000002",
+        signing_pub: b64(rigPub),
+        valid_from: "2026-05-04T00:00:00Z",
+        registered_at: "2026-05-04T00:00:00Z",
+      }),
+      "cert-witness:witness-foo-bar:2026-05-04T00:00:00Z": JSON.stringify({
+        witness_id: "bar",
+        rig_id: "foo",  // pairs with a *different* rig
+        signing_pub: b64(witnessPub),
+        valid_from: "2026-05-04T00:00:00Z",
+        registered_at: "2026-05-04T00:00:00Z",
+      }),
+    });
+    const body = signAndAttach(makeBody(), rigPriv, witnessPriv, "bob-rig-2026", "witness-foo-bar");
+    const result = await verifyHilEvidence(env, body);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(403);
+      expect(result.error).toMatch(/scope|rig_id|pairing/i);
+    }
+  });
+});

--- a/functions/v2/_lib/verify-hil-evidence.ts
+++ b/functions/v2/_lib/verify-hil-evidence.ts
@@ -1,0 +1,121 @@
+/**
+ * Verify a cert-intake POST body's rig + witness signatures.
+ *
+ * Flow:
+ *   1. Validate sig blobs (kid + sig strings present).
+ *   2. Validate ran_at is finite number; convert to ISO string for window-check.
+ *   3. Resolve rig_signature.kid via cert-rig-resolve.
+ *   4. Resolve witness_signature.kid via cert-witness-resolve.
+ *   5. Cross-check witness.rig_id === rig.rig_id (scope check).
+ *   6. Reconstruct canonical_json(body - {rig_signature, witness_signature}).
+ *   7. Web Crypto Ed25519 SPKI direct verify of rig sig.
+ *   8. Web Crypto Ed25519 SPKI direct verify of witness sig.
+ *   9. Return {ok, rig, witness} or structured error.
+ *
+ * Web Crypto Ed25519 SPKI direct verify pattern: same as Plan 4 deviation B6
+ * (functions/v2/_lib/jwt-verify.ts). Bypasses rcan-ts.verifyBody which assumes
+ * pq-injected fields.
+ */
+
+import { canonicalJson } from "rcan-ts";
+import type { RigKidMapping, WitnessKidMapping } from "./types.js";
+import { resolveRigKid } from "./cert-rig-resolve.js";
+import { resolveWitnessKid } from "./cert-witness-resolve.js";
+
+export type VerifyHilOk = { ok: true; rig: RigKidMapping; witness: WitnessKidMapping };
+export type VerifyHilErr = { ok: false; status: number; error: string };
+export type VerifyHilResult = VerifyHilOk | VerifyHilErr;
+
+const RAW_ED25519_PUB_LEN = 32;
+const SPKI_ED25519_PREFIX = new Uint8Array([
+  0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x21, 0x00,
+]);
+
+function b64decode(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function rawPubToSpki(rawPub: Uint8Array): Uint8Array {
+  if (rawPub.length !== RAW_ED25519_PUB_LEN) {
+    throw new Error(`Ed25519 raw pubkey must be ${RAW_ED25519_PUB_LEN} bytes; got ${rawPub.length}`);
+  }
+  const spki = new Uint8Array(SPKI_ED25519_PREFIX.length + RAW_ED25519_PUB_LEN);
+  spki.set(SPKI_ED25519_PREFIX, 0);
+  spki.set(rawPub, SPKI_ED25519_PREFIX.length);
+  return spki;
+}
+
+async function verifyEd25519(pubB64: string, msg: Uint8Array, sigB64: string): Promise<boolean> {
+  const rawPub = b64decode(pubB64);
+  const spki = rawPubToSpki(rawPub);
+  const key = await crypto.subtle.importKey(
+    "spki",
+    spki,
+    { name: "Ed25519" },
+    false,
+    ["verify"],
+  );
+  const sig = b64decode(sigB64);
+  return crypto.subtle.verify(
+    { name: "Ed25519" },
+    key,
+    sig,
+    msg,
+  );
+}
+
+export async function verifyHilEvidence(
+  env: { RRF_KV: KVNamespace },
+  payload: Record<string, unknown>,
+): Promise<VerifyHilResult> {
+  const rigSig = payload["rig_signature"];
+  const witnessSig = payload["witness_signature"];
+  if (!rigSig || typeof rigSig !== "object" || !witnessSig || typeof witnessSig !== "object") {
+    return { ok: false, status: 400, error: "rig_signature and witness_signature both required" };
+  }
+  const rigKid = (rigSig as { kid?: unknown }).kid;
+  const rigSigB64 = (rigSig as { sig?: unknown }).sig;
+  const witnessKid = (witnessSig as { kid?: unknown }).kid;
+  const witnessSigB64 = (witnessSig as { sig?: unknown }).sig;
+  if (typeof rigKid !== "string" || typeof rigSigB64 !== "string" ||
+      typeof witnessKid !== "string" || typeof witnessSigB64 !== "string") {
+    return { ok: false, status: 400, error: "rig_signature and witness_signature must each have string kid + sig" };
+  }
+
+  const ranAt = payload["ran_at"];
+  if (typeof ranAt !== "number" || !Number.isFinite(ranAt)) {
+    return { ok: false, status: 400, error: "ran_at missing or not a finite number" };
+  }
+  const ranAtIso = new Date(ranAt * 1000).toISOString();
+
+  const rig = await resolveRigKid(env, rigKid, ranAtIso);
+  if (!rig) {
+    return { ok: false, status: 403, error: `rig kid ${rigKid} not registered or outside validity window for ran_at ${ranAtIso}` };
+  }
+  const witness = await resolveWitnessKid(env, witnessKid, ranAtIso);
+  if (!witness) {
+    return { ok: false, status: 403, error: `witness kid ${witnessKid} not registered or outside validity window for ran_at ${ranAtIso}` };
+  }
+  if (witness.rig_id !== rig.rig_id) {
+    return { ok: false, status: 403, error: `witness ${witnessKid} is paired with rig ${witness.rig_id}, not ${rig.rig_id} (scope mismatch)` };
+  }
+
+  const core: Record<string, unknown> = { ...payload };
+  delete core["rig_signature"];
+  delete core["witness_signature"];
+  const msg = new TextEncoder().encode(canonicalJson(core));
+
+  const rigOk = await verifyEd25519(rig.signing_pub, msg, rigSigB64);
+  if (!rigOk) {
+    return { ok: false, status: 401, error: `rig signature did not verify against registered pub for kid ${rigKid}` };
+  }
+  const witnessOk = await verifyEd25519(witness.signing_pub, msg, witnessSigB64);
+  if (!witnessOk) {
+    return { ok: false, status: 401, error: `witness signature did not verify against registered pub for kid ${witnessKid}` };
+  }
+
+  return { ok: true, rig, witness };
+}

--- a/functions/v2/cert-intake/[cert_id]/index.ts
+++ b/functions/v2/cert-intake/[cert_id]/index.ts
@@ -1,0 +1,47 @@
+/**
+ * GET /v2/cert-intake/{cert_id}
+ *
+ * Bearer-gated (M2M_TRUSTED JWT). Returns the full as-submitted payload
+ * (augmented with server-resolved rrn). Mirrors compliance-bundle/[bundle_id]/index.ts.
+ */
+
+import { verifyM2mTrustedJwt } from "../../_lib/jwt-verify.js";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+  RRF_ROOT_PUBKEY?: string;
+}
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env, "cert_id"> = async ({ env, request, params }) => {
+  const certId = params["cert_id"] as string;
+  if (!certId || !certId.startsWith("cert_")) {
+    return json({ error: "cert_id missing or malformed" }, 400);
+  }
+
+  // Read first to find the RRN — needed for JWT scope check.
+  const raw = await env.RRF_KV.get(`cert-intake:${certId}`, "text");
+  if (!raw) return json({ error: `cert_id ${certId} not found` }, 404);
+
+  let payload: Record<string, unknown>;
+  try { payload = JSON.parse(raw) as Record<string, unknown>; }
+  catch { return json({ error: "corrupt cert-intake record" }, 500); }
+
+  const rrn = payload["rrn"];
+  if (typeof rrn !== "string" || !/^RRN-\d{12}$/.test(rrn)) {
+    return json({ error: "stored cert-intake has malformed rrn" }, 500);
+  }
+
+  const jwtResult = await verifyM2mTrustedJwt(env, request, rrn as `RRN-${string}`);
+  if (!jwtResult.ok) {
+    return json({ error: jwtResult.error }, jwtResult.status);
+  }
+
+  return json(payload, 200);
+};

--- a/functions/v2/cert-intake/[cert_id]/proof.test.ts
+++ b/functions/v2/cert-intake/[cert_id]/proof.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { onRequestGet } from "./proof.js";
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    env: {
+      RRF_KV: {
+        get: vi.fn(async (k: string) => store[k] ?? null),
+        put: vi.fn(),
+        list: vi.fn(async ({ prefix, cursor }: { prefix: string; cursor?: string }) => {
+          const allKeys = Object.keys(store).filter(k => k.startsWith(prefix)).sort();
+          const start = cursor ? allKeys.indexOf(cursor) + 1 : 0;
+          const slice = allKeys.slice(start, start + 1000);
+          const nextCursor = (start + 1000) < allKeys.length ? slice[slice.length - 1] : undefined;
+          return {
+            keys: slice.map(name => ({ name })),
+            list_complete: !nextCursor,
+            cursor: nextCursor,
+          };
+        }),
+        delete: vi.fn(),
+      } as unknown as KVNamespace,
+    },
+    store,
+  };
+}
+
+describe("GET /v2/cert-intake/{cert_id}/proof", () => {
+  it("returns 200 with the log entry when found", async () => {
+    const certId = "cert_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const { env } = makeEnv({
+      "cert-intake-log:000000000001": JSON.stringify({
+        cert_id: certId,
+        rrn: "RRN-000000000002",
+        property_id: "SF-001",
+        transparency_log_index: 1,
+        rrf_log_signature: { kid: "rrf-root", alg: "Ed25519", sig: "x" },
+      }),
+    });
+    const res = await onRequestGet({ env, params: { cert_id: certId } } as unknown as Parameters<typeof onRequestGet>[0]);
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.cert_id).toBe(certId);
+    expect(body.transparency_log_index).toBe(1);
+  });
+
+  it("returns 404 when cert_id is not found", async () => {
+    const { env } = makeEnv();
+    const res = await onRequestGet({ env, params: { cert_id: "cert_nonexistent" } } as unknown as Parameters<typeof onRequestGet>[0]);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 on malformed cert_id (no cert_ prefix)", async () => {
+    const { env } = makeEnv();
+    const res = await onRequestGet({ env, params: { cert_id: "garbage-no-prefix" } } as unknown as Parameters<typeof onRequestGet>[0]);
+    expect(res.status).toBe(400);
+  });
+
+  it("paginates over >1000 log entries (Plan 4 fix-loop)", async () => {
+    const targetId = "cert_target";
+    const initial: Record<string, string> = {};
+    for (let i = 1; i <= 1500; i++) {
+      const id = i === 1500 ? targetId : `cert_${i.toString().padStart(32, "0")}`;
+      initial[`cert-intake-log:${i.toString().padStart(12, "0")}`] = JSON.stringify({
+        cert_id: id,
+        transparency_log_index: i,
+      });
+    }
+    const { env } = makeEnv(initial);
+    const res = await onRequestGet({ env, params: { cert_id: targetId } } as unknown as Parameters<typeof onRequestGet>[0]);
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.cert_id).toBe(targetId);
+    expect(body.transparency_log_index).toBe(1500);
+  });
+});

--- a/functions/v2/cert-intake/[cert_id]/proof.ts
+++ b/functions/v2/cert-intake/[cert_id]/proof.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /v2/cert-intake/{cert_id}/proof
+ *
+ * Public (no auth). Returns the RRF-root-signed log entry for the cert_id.
+ * Walks cert-intake-log:<idx> with paginated cursor (KV list returns ≤1000
+ * keys per page; Plan 4 fix-loop pattern).
+ *
+ * Body NOT included — only the log entry, which contains the rig + witness +
+ * RRF-root signatures and the index. Audit consumers can verify the
+ * rrf_log_signature against the rrf:root:pubkey public key.
+ */
+
+import type { CertIntakeEntry } from "../../_lib/types.js";
+
+export interface Env { RRF_KV: KVNamespace }
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env> = async ({ env, params }) => {
+  const certId = params.cert_id as string | undefined;
+  if (!certId || !certId.startsWith("cert_")) {
+    return json({ error: "cert_id missing or malformed" }, 400);
+  }
+
+  let cursor: string | undefined;
+  while (true) {
+    const result: { keys: Array<{ name: string }>; list_complete: boolean; cursor?: string } =
+      await env.RRF_KV.list({ prefix: "cert-intake-log:", cursor: cursor ?? undefined });
+    for (const k of result.keys) {
+      const raw = await env.RRF_KV.get(k.name, "text");
+      if (!raw) continue;
+      let entry: CertIntakeEntry;
+      try { entry = JSON.parse(raw) as CertIntakeEntry; }
+      catch { continue; }
+      if (entry.cert_id === certId) {
+        return json(entry);
+      }
+    }
+    if (result.list_complete) break;
+    cursor = result.cursor;
+    if (!cursor) break;
+  }
+
+  return json({ error: `cert_id ${certId} not found in transparency log` }, 404);
+};

--- a/functions/v2/cert-intake/handlers/v10.test.ts
+++ b/functions/v2/cert-intake/handlers/v10.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from "vitest";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { canonicalJson } from "rcan-ts";
+import { handleV10 } from "./v10.js";
+
+function b64(u8: Uint8Array): string { return Buffer.from(u8).toString("base64"); }
+function b64buf(b: ArrayBuffer): string { return Buffer.from(new Uint8Array(b)).toString("base64"); }
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    env: {
+      RRF_KV: {
+        get: vi.fn(async (k: string) => store[k] ?? null),
+        put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+        list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+          keys: Object.keys(store).filter(k => k.startsWith(prefix)).map(name => ({ name })),
+          list_complete: true,
+        })),
+        delete: vi.fn(),
+      } as unknown as KVNamespace,
+    },
+    store,
+  };
+}
+
+async function setupRigAndWitness(store: Record<string, string>) {
+  const rigPriv = crypto.getRandomValues(new Uint8Array(32));
+  const rigPub = ed25519.getPublicKey(rigPriv);
+  const witnessPriv = crypto.getRandomValues(new Uint8Array(32));
+  const witnessPub = ed25519.getPublicKey(witnessPriv);
+  store["cert-rig:bob-rig-2026:2026-05-04T00:00:00Z"] = JSON.stringify({
+    rig_id: "bob", rrn: "RRN-000000000002", signing_pub: b64(rigPub),
+    valid_from: "2026-05-04T00:00:00Z", registered_at: "2026-05-04T00:00:00Z",
+  });
+  store["cert-witness:witness-bob-craigm:2026-05-04T00:00:00Z"] = JSON.stringify({
+    witness_id: "craigm", rig_id: "bob", signing_pub: b64(witnessPub),
+    valid_from: "2026-05-04T00:00:00Z", registered_at: "2026-05-04T00:00:00Z",
+  });
+  // Plan 4's RRF root signing key — PKCS8, matching signLogEntry's importKey contract.
+  const rootKp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+  const rootPrivDer = await crypto.subtle.exportKey("pkcs8", (rootKp as CryptoKeyPair).privateKey);
+  const rootPubDer = await crypto.subtle.exportKey("spki", (rootKp as CryptoKeyPair).publicKey);
+  store["rrf:root:privkey"] = b64buf(rootPrivDer);
+  store["rrf:root:pubkey"] = `-----BEGIN PUBLIC KEY-----\n${b64buf(rootPubDer)}\n-----END PUBLIC KEY-----\n`;
+  return { rigPriv, witnessPriv };
+}
+
+function makeBody(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: "1.0",
+    property_id: "SF-001",
+    rig: "bob",
+    robot_class: "so-arm101",
+    ran_at: 1777939200.0,  // 2026-05-05T00:00:00Z
+    iterations: 10,
+    results: [{ iteration: 1, latency_ms: 47, pass: true }],
+    all_pass: true,
+    ...overrides,
+  };
+}
+
+function signAndAttach(body: Record<string, unknown>, rigPriv: Uint8Array, witnessPriv: Uint8Array) {
+  const core = { ...body };
+  const msg = new TextEncoder().encode(canonicalJson(core));
+  return {
+    ...body,
+    rig_signature:     { kid: "bob-rig-2026",        alg: "Ed25519", sig: b64(ed25519.sign(msg, rigPriv)) },
+    witness_signature: { kid: "witness-bob-craigm", alg: "Ed25519", sig: b64(ed25519.sign(msg, witnessPriv)) },
+  };
+}
+
+describe("cert-intake handlers/v10", () => {
+  it("returns 201 with cert_id, rrn, transparency_log_index, logged_at, proof_url on happy path", async () => {
+    const { env, store } = makeEnv();
+    const { rigPriv, witnessPriv } = await setupRigAndWitness(store);
+    const body = signAndAttach(makeBody(), rigPriv, witnessPriv);
+    const res = await handleV10(body as Record<string, unknown>, env);
+    expect(res.status).toBe(201);
+    const json = await res.json() as Record<string, unknown>;
+    expect((json.cert_id as string).startsWith("cert_")).toBe(true);
+    expect(json.rrn).toBe("RRN-000000000002");
+    expect(json.transparency_log_index).toBe(1);
+    expect(typeof json.logged_at).toBe("string");
+    expect(json.proof_url).toBe(`/v2/cert-intake/${json.cert_id}/proof`);
+    // KV side effects.
+    expect(store["counter:cert-log"]).toBe("1");
+    expect(store[`cert-intake:${json.cert_id}`]).toBeDefined();
+    expect(store["cert-intake-log:000000000001"]).toBeDefined();
+  });
+
+  it("returns 409 on second POST with identical body (idempotency)", async () => {
+    const { env, store } = makeEnv();
+    const { rigPriv, witnessPriv } = await setupRigAndWitness(store);
+    const body = signAndAttach(makeBody(), rigPriv, witnessPriv);
+    const first = await handleV10(body as Record<string, unknown>, env);
+    expect(first.status).toBe(201);
+    const second = await handleV10(body as Record<string, unknown>, env);
+    expect(second.status).toBe(409);
+  });
+
+  it("returns 400 when property_id missing", async () => {
+    const { env, store } = makeEnv();
+    const { rigPriv, witnessPriv } = await setupRigAndWitness(store);
+    const body = signAndAttach(makeBody({ property_id: undefined }), rigPriv, witnessPriv);
+    delete (body as { property_id?: unknown }).property_id;
+    const res = await handleV10(body as Record<string, unknown>, env);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when rig sig is wrong", async () => {
+    const { env, store } = makeEnv();
+    const { rigPriv: _unused, witnessPriv } = await setupRigAndWitness(store);
+    const wrongPriv = crypto.getRandomValues(new Uint8Array(32));
+    const body = signAndAttach(makeBody(), wrongPriv, witnessPriv);
+    const res = await handleV10(body as Record<string, unknown>, env);
+    expect(res.status).toBe(401);
+  });
+});

--- a/functions/v2/cert-intake/handlers/v10.ts
+++ b/functions/v2/cert-intake/handlers/v10.ts
@@ -1,0 +1,116 @@
+/**
+ * Schema v1.0 handler for /v2/cert-intake POST.
+ *
+ * Flow:
+ *   1. Validate required fields (property_id, ran_at, iterations, all_pass).
+ *   2. Verify rig + witness sigs via verifyHilEvidence (Task 4).
+ *   3. Derive cert_id = "cert_" + sha256(canonical_json(body - {rig_signature, witness_signature}))[:32].
+ *   4. Idempotency check (cert-intake:<cert_id>).
+ *   5. Counter increment (counter:cert-log).
+ *   6. Build CertIntakeEntry with rrn from rig record.
+ *   7. RRF-root sign via signLogEntry (Plan 4 _lib/rrf-log-sign.ts).
+ *   8. KV writes in counter -> log-index -> payload order (partial-write coherence).
+ *   9. Return 201 JSON.
+ *
+ * Augments stored payload with server-resolved rrn so GET-by-id can JWT-scope-check
+ * without re-doing kid resolution.
+ */
+
+import { canonicalJson } from "rcan-ts";
+import type { CertIntakeEntry } from "../../_lib/types.js";
+import { verifyHilEvidence } from "../../_lib/verify-hil-evidence.js";
+import { signLogEntry } from "../../_lib/rrf-log-sign.js";
+
+export interface Env { RRF_KV: KVNamespace }
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function deriveCertId(payload: Record<string, unknown>): Promise<string> {
+  const core: Record<string, unknown> = { ...payload };
+  delete core["rig_signature"];
+  delete core["witness_signature"];
+  const bytes = new TextEncoder().encode(canonicalJson(core));
+  const hash = await crypto.subtle.digest("SHA-256", bytes as unknown as BufferSource);
+  const hex = Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2, "0")).join("");
+  return `cert_${hex.slice(0, 32)}`;
+}
+
+function pad12(n: number): string { return String(n).padStart(12, "0"); }
+
+export async function handleV10(payload: Record<string, unknown>, env: Env): Promise<Response> {
+  const propertyId = payload["property_id"];
+  if (typeof propertyId !== "string" || propertyId.length === 0) {
+    return json({ error: "property_id missing or not a string" }, 400);
+  }
+  if (typeof payload["schema_version"] !== "string") {
+    return json({ error: "schema_version missing or not a string" }, 400);
+  }
+  if (typeof payload["ran_at"] !== "number") {
+    return json({ error: "ran_at missing or not a number" }, 400);
+  }
+  if (typeof payload["iterations"] !== "number") {
+    return json({ error: "iterations missing or not a number" }, 400);
+  }
+  if (typeof payload["all_pass"] !== "boolean") {
+    return json({ error: "all_pass missing or not a boolean" }, 400);
+  }
+
+  const verifyResult = await verifyHilEvidence(env, payload);
+  if (!verifyResult.ok) {
+    return json({ error: verifyResult.error }, verifyResult.status);
+  }
+
+  const certId = await deriveCertId(payload);
+
+  const existing = await env.RRF_KV.get(`cert-intake:${certId}`, "text");
+  if (existing) {
+    return json({ error: `cert_id ${certId} already exists in transparency log`, cert_id: certId }, 409);
+  }
+
+  // Counter increment. NOTE: get→put races under concurrent POSTs (Plan 4 spec D6
+  // posture accepted this; matches compliance-bundle/handlers/v10.ts pattern).
+  const counterStr = await env.RRF_KV.get("counter:cert-log", "text");
+  const next = (counterStr ? parseInt(counterStr, 10) : 0) + 1;
+
+  const loggedAt = new Date().toISOString();
+  const rigSig = payload["rig_signature"] as CertIntakeEntry["rig_signature"];
+  const witnessSig = payload["witness_signature"] as CertIntakeEntry["witness_signature"];
+  const entry: Omit<CertIntakeEntry, "rrf_log_signature"> = {
+    cert_id: certId,
+    rrn: verifyResult.rig.rrn,
+    property_id: propertyId,
+    schema_version: payload["schema_version"] as string,
+    rig_id: verifyResult.rig.rig_id,
+    ran_at: payload["ran_at"] as number,
+    all_pass: payload["all_pass"] as boolean,
+    iterations: payload["iterations"] as number,
+    transparency_log_index: next,
+    logged_at: loggedAt,
+    rig_signature: rigSig,
+    witness_signature: witnessSig,
+  };
+
+  const rrfLogSig = await signLogEntry(env, entry);
+  const fullEntry: CertIntakeEntry = { ...entry, rrf_log_signature: rrfLogSig };
+
+  // Counter -> log-index -> payload order (Plan 4 partial-write coherence).
+  // Payload is augmented with the server-resolved rrn so GET-by-id can
+  // JWT-scope-check without re-doing the kid resolution.
+  const storedPayload = { ...payload, rrn: verifyResult.rig.rrn };
+  await env.RRF_KV.put("counter:cert-log", String(next));
+  await env.RRF_KV.put(`cert-intake-log:${pad12(next)}`, JSON.stringify(fullEntry), { expirationTtl: 365 * 24 * 3600 * 10 });
+  await env.RRF_KV.put(`cert-intake:${certId}`, JSON.stringify(storedPayload), { expirationTtl: 365 * 24 * 3600 * 10 });
+
+  return json({
+    cert_id: certId,
+    rrn: verifyResult.rig.rrn,
+    transparency_log_index: next,
+    logged_at: loggedAt,
+    proof_url: `/v2/cert-intake/${certId}/proof`,
+  }, 201);
+}

--- a/functions/v2/cert-intake/index.test.ts
+++ b/functions/v2/cert-intake/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import { onRequestPost } from "./index.js";
+
+function makeEnv() {
+  const store: Record<string, string> = {};
+  return {
+    env: {
+      RRF_KV: {
+        get: vi.fn(async (k: string) => store[k] ?? null),
+        put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+        list: vi.fn(async () => ({ keys: [], list_complete: true })),
+        delete: vi.fn(),
+      } as unknown as KVNamespace,
+    },
+    store,
+  };
+}
+
+function mkReq(body: unknown): Request {
+  return new Request("https://x/v2/cert-intake", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /v2/cert-intake", () => {
+  it("returns 400 on invalid JSON body", async () => {
+    const { env } = makeEnv();
+    const res = await onRequestPost({ env, request: mkReq("not-json") } as unknown as Parameters<typeof onRequestPost>[0]);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when schema_version missing", async () => {
+    const { env } = makeEnv();
+    const res = await onRequestPost({ env, request: mkReq({ no: "version" }) } as unknown as Parameters<typeof onRequestPost>[0]);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 415 on unsupported schema_version", async () => {
+    const { env } = makeEnv();
+    const res = await onRequestPost({ env, request: mkReq({ schema_version: "99.99" }) } as unknown as Parameters<typeof onRequestPost>[0]);
+    expect(res.status).toBe(415);
+  });
+});

--- a/functions/v2/cert-intake/index.ts
+++ b/functions/v2/cert-intake/index.ts
@@ -1,0 +1,49 @@
+/**
+ * /v2/cert-intake
+ *
+ * POST: schema-version routing -> handlers/v10 (or 415 on unsupported version).
+ * GET /v2/cert-intake/{cert_id}: full payload, Bearer-gated via M2M_TRUSTED JWT
+ *   (handled by [cert_id]/index.ts).
+ * GET /v2/cert-intake/{cert_id}/proof: public log entry + RRF root sig
+ *   (handled by [cert_id]/proof.ts).
+ *
+ * Plan 6 Phase 4 — Track-3 HIL property evidence.
+ */
+
+import { handleV10 } from "./handlers/v10.js";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+  RRF_ROOT_PUBKEY?: string;
+}
+
+const SCHEMA_VERSION_HANDLERS: Record<string, (p: Record<string, unknown>, env: Env) => Promise<Response>> = {
+  "1.0": handleV10,
+};
+
+function json(obj: unknown, status = 200): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
+  let payload: Record<string, unknown>;
+  try {
+    payload = (await request.json()) as Record<string, unknown>;
+  } catch {
+    return json({ error: "invalid JSON body" }, 400);
+  }
+  const schemaVersion = payload["schema_version"];
+  if (typeof schemaVersion !== "string") {
+    return json({ error: "schema_version required" }, 400);
+  }
+  const handler = SCHEMA_VERSION_HANDLERS[schemaVersion];
+  if (!handler) {
+    return json({
+      error: `Unsupported schema_version: ${schemaVersion} (supported: ${Object.keys(SCHEMA_VERSION_HANDLERS).join(", ")})`,
+    }, 415);
+  }
+  return handler(payload, env);
+};

--- a/scripts/register-cert-rig.ts
+++ b/scripts/register-cert-rig.ts
@@ -1,0 +1,66 @@
+/**
+ * Generate a cert-rig:<kid>:<registered_at> KV record for `wrangler kv bulk put`.
+ *
+ * Plan 6 Phase 4 — registers a HIL rig kid so cert-intake POST can resolve
+ * its sigs. Mirrors register-aggregator-kid.ts (Plan 4) shape.
+ *
+ * Usage:
+ *   tsx scripts/register-cert-rig.ts \
+ *     --kid bob-rig-2026 \
+ *     --rrn RRN-000000000002 \
+ *     --signing-pub-b64 <ed25519-raw-pubkey-base64> \
+ *     [--rig-id bob] \
+ *     [--valid-until 2027-05-04T00:00:00Z] \
+ *     > rig.json
+ *   wrangler kv bulk put --namespace-id <NS_ID> rig.json
+ */
+
+import { parseArgs } from "node:util";
+import { writeFileSync } from "node:fs";
+
+const { values } = parseArgs({
+  options: {
+    kid: { type: "string" },
+    rrn: { type: "string" },
+    "signing-pub-b64": { type: "string" },
+    "rig-id": { type: "string" },
+    "valid-until": { type: "string" },
+    out: { type: "string" },
+  },
+});
+
+const kid = values.kid;
+const rrn = values.rrn;
+const signingPub = values["signing-pub-b64"];
+if (!kid || !rrn || !signingPub) {
+  console.error("error: --kid, --rrn, --signing-pub-b64 are required");
+  process.exit(2);
+}
+if (!/^RRN-\d{12}$/.test(rrn)) {
+  console.error(`error: --rrn must match RRN-NNNNNNNNNNNN; got ${rrn}`);
+  process.exit(2);
+}
+
+const rigId = values["rig-id"] ?? kid.split("-")[0];
+const registeredAt = new Date().toISOString();
+const mapping = {
+  rig_id: rigId,
+  rrn,
+  signing_pub: signingPub,
+  valid_from: registeredAt,
+  valid_until: values["valid-until"],
+  registered_at: registeredAt,
+};
+
+const bulkRecord = [{
+  key: `cert-rig:${kid}:${registeredAt}`,
+  value: JSON.stringify(mapping),
+}];
+
+const out = JSON.stringify(bulkRecord, null, 2);
+if (values.out) {
+  writeFileSync(values.out, out);
+  console.error(`wrote ${values.out}`);
+} else {
+  process.stdout.write(out + "\n");
+}

--- a/scripts/register-cert-rig.ts
+++ b/scripts/register-cert-rig.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env tsx
 /**
  * Generate a cert-rig:<kid>:<registered_at> KV record for `wrangler kv bulk put`.
  *
@@ -12,7 +13,7 @@
  *     [--rig-id bob] \
  *     [--valid-until 2027-05-04T00:00:00Z] \
  *     > rig.json
- *   wrangler kv bulk put --namespace-id <NS_ID> rig.json
+ *   wrangler kv:bulk put --binding RRF_KV rig.json
  */
 
 import { parseArgs } from "node:util";

--- a/scripts/register-cert-witness.ts
+++ b/scripts/register-cert-witness.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env tsx
 /**
  * Generate a cert-witness:<kid>:<registered_at> KV record for `wrangler kv bulk put`.
  *
@@ -11,7 +12,7 @@
  *     --signing-pub-b64 <ed25519-raw-pubkey-base64> \
  *     [--valid-until 2027-05-04T00:00:00Z] \
  *     > witness.json
- *   wrangler kv bulk put --namespace-id <NS_ID> witness.json
+ *   wrangler kv:bulk put --binding RRF_KV witness.json
  */
 
 import { parseArgs } from "node:util";

--- a/scripts/register-cert-witness.ts
+++ b/scripts/register-cert-witness.ts
@@ -1,0 +1,61 @@
+/**
+ * Generate a cert-witness:<kid>:<registered_at> KV record for `wrangler kv bulk put`.
+ *
+ * Plan 6 Phase 4 — registers a HIL witness kid paired with a specific rig.
+ *
+ * Usage:
+ *   tsx scripts/register-cert-witness.ts \
+ *     --kid witness-bob-craigm \
+ *     --witness-id craigm \
+ *     --rig-id bob \
+ *     --signing-pub-b64 <ed25519-raw-pubkey-base64> \
+ *     [--valid-until 2027-05-04T00:00:00Z] \
+ *     > witness.json
+ *   wrangler kv bulk put --namespace-id <NS_ID> witness.json
+ */
+
+import { parseArgs } from "node:util";
+import { writeFileSync } from "node:fs";
+
+const { values } = parseArgs({
+  options: {
+    kid: { type: "string" },
+    "witness-id": { type: "string" },
+    "rig-id": { type: "string" },
+    "signing-pub-b64": { type: "string" },
+    "valid-until": { type: "string" },
+    out: { type: "string" },
+  },
+});
+
+const kid = values.kid;
+const witnessId = values["witness-id"];
+const rigId = values["rig-id"];
+const signingPub = values["signing-pub-b64"];
+if (!kid || !witnessId || !rigId || !signingPub) {
+  console.error("error: --kid, --witness-id, --rig-id, --signing-pub-b64 are required");
+  process.exit(2);
+}
+
+const registeredAt = new Date().toISOString();
+const mapping = {
+  witness_id: witnessId,
+  rig_id: rigId,
+  signing_pub: signingPub,
+  valid_from: registeredAt,
+  valid_until: values["valid-until"],
+  registered_at: registeredAt,
+};
+
+const bulkRecord = [{
+  key: `cert-witness:${kid}:${registeredAt}`,
+  value: JSON.stringify(mapping),
+}];
+
+const out = JSON.stringify(bulkRecord, null, 2);
+if (values.out) {
+  writeFileSync(values.out, out);
+  console.error(`wrote ${values.out}`);
+} else {
+  process.stdout.write(out + "\n");
+}


### PR DESCRIPTION
## Summary

- New `POST /v2/cert-intake` endpoint for Track-3 HIL property evidence (SF-001, SF-002, GW-001 today; Phase 5 schemas extend additively).
- `GET /v2/cert-intake/{cert_id}` Bearer-gated full payload retrieval (M2M_TRUSTED JWT scoped to RRN).
- `GET /v2/cert-intake/{cert_id}/proof` public RRF-root-signed log entry (no auth).
- Two new KV namespaces: `cert-rig:` and `cert-witness:` with their own resolvers and types (distinct from Plan 4's RAN-bound `kid:` — rigs + witnesses aren't authorities).
- Three new `_lib` helpers (`cert-rig-resolve`, `cert-witness-resolve`, `verify-hil-evidence`); existing `rrf-log-sign.ts` + `jwt-verify.ts` reused as-is.
- Two new registration scripts (`register-cert-rig.ts`, `register-cert-witness.ts`) for one-time kid bootstrapping.
- Separate transparency log (`counter:cert-log` + `cert-intake-log:<idx>`) — same RRF-root-sign integrity, distinct evidence-class semantics from `compliance-bundle-log`.

Closes Plan 6 Phase 4 Blocker 2 (operator session no longer blocked on the missing cert-intake endpoint).

Spec: `opencastor-ops/docs/superpowers/specs/2026-05-04-cert-intake-design.md`.
Plan: `opencastor-ops/docs/superpowers/plans/2026-05-04-cert-intake.md`.
Plan-body amendments to cert-tracks Phase 4 Tasks 16-18 already pushed at `craigm26/opencastor-ops@55d5eab`.

## Architecture notes

- **Sig-chain auth on POST.** No `Authorization` header. Rig + witness Ed25519 sigs verify against registered KV records; failure to verify = 401. The cert claim *is* the signature chain.
- **Content-derived `cert_id`.** `cert_<sha256(canonical_json(body - signatures))[:32]>`. Same body → same cert_id → 409 on retry. Operator never supplies it.
- **Stored payload augmentation.** Handler writes `{...payload, rrn}` to `cert-intake:<id>` so the GET-by-id can JWT-scope-check without re-resolving the rig kid.
- **KV write order: counter → log-index → payload** (Plan 4 partial-write coherence).

## Test plan

- [x] Vitest unit coverage for all helpers + handlers + dispatcher + proof endpoint (23 new tests; full suite 266 → 289)
- [x] Pagination tested at >1000 entries
- [x] Idempotency tested (second POST → 409)
- [x] Sig-failure tested (registered different pub than signing key → 401)
- [ ] **Post-merge:** prod KV bootstrap (rig + witness registrations via the new scripts) + Plan 6 Phase 4 Task 16 (SF-001 operator session) end-to-end against the live endpoint

## Out of scope (tracked, not in this PR)

- Phase 5 schema versions (`GATED-MOTION-100`, `REPLAY-10`) — additive via `SCHEMA_VERSION_HANDLERS` map when Plan 6 Phase 5 starts.
- Multi-witness signatures (v1.0 = 1 rig + 1 witness exactly).
- Cross-rig witness pairing.
- Rig + witness rotation tooling (KV schema supports `valid_until`; runbook is a downstream operations task).
- Auditor-facing UI viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)