### PR TITLE
fix(cert-intake): drop double-encode of canonicalJson result

### DIFF
--- a/functions/v2/_lib/verify-hil-evidence.test.ts
+++ b/functions/v2/_lib/verify-hil-evidence.test.ts
@@ -40,7 +40,7 @@ function signAndAttach(body: Record<string, unknown>, rigPriv: Uint8Array, witne
   const core = { ...body };
   delete (core as { rig_signature?: unknown }).rig_signature;
   delete (core as { witness_signature?: unknown }).witness_signature;
-  const msg = new TextEncoder().encode(canonicalJson(core));
+  const msg = canonicalJson(core);
   const rigSig = ed25519.sign(msg, rigPriv);
   const witnessSig = ed25519.sign(msg, witnessPriv);
   return {

--- a/functions/v2/_lib/verify-hil-evidence.ts
+++ b/functions/v2/_lib/verify-hil-evidence.ts
@@ -106,7 +106,7 @@ export async function verifyHilEvidence(
   const core: Record<string, unknown> = { ...payload };
   delete core["rig_signature"];
   delete core["witness_signature"];
-  const msg = new TextEncoder().encode(canonicalJson(core));
+  const msg = canonicalJson(core);
 
   const rigOk = await verifyEd25519(rig.signing_pub, msg, rigSigB64);
   if (!rigOk) {

--- a/functions/v2/cert-intake/handlers/v10.test.ts
+++ b/functions/v2/cert-intake/handlers/v10.test.ts
@@ -62,7 +62,7 @@ function makeBody(overrides: Record<string, unknown> = {}) {
 
 function signAndAttach(body: Record<string, unknown>, rigPriv: Uint8Array, witnessPriv: Uint8Array) {
   const core = { ...body };
-  const msg = new TextEncoder().encode(canonicalJson(core));
+  const msg = canonicalJson(core);
   return {
     ...body,
     rig_signature:     { kid: "bob-rig-2026",        alg: "Ed25519", sig: b64(ed25519.sign(msg, rigPriv)) },

--- a/functions/v2/cert-intake/handlers/v10.ts
+++ b/functions/v2/cert-intake/handlers/v10.ts
@@ -34,7 +34,7 @@ async function deriveCertId(payload: Record<string, unknown>): Promise<string> {
   const core: Record<string, unknown> = { ...payload };
   delete core["rig_signature"];
   delete core["witness_signature"];
-  const bytes = new TextEncoder().encode(canonicalJson(core));
+  const bytes = canonicalJson(core);
   const hash = await crypto.subtle.digest("SHA-256", bytes as unknown as BufferSource);
   const hex = Array.from(new Uint8Array(hash)).map(b => b.toString(16).padStart(2, "0")).join("");
   return `cert_${hex.slice(0, 32)}`;


### PR DESCRIPTION
## Summary

Critical fix to the cert-intake endpoint family (PR #89). Removes a TextEncoder.encode() wrapper around canonicalJson(...) at four sites; canonicalJson already returns Uint8Array, so the wrapper was producing the wrong bytes.

## How the bug landed in main

Vitest tests self-cancel: the sign-side test fixture used the same `TextEncoder.encode(canonicalJson(...))` pattern as the verify-side impl, so the wrong bytes match on both sides and the round-trip succeeds in tests. The bug only manifests when the signer is in a different language (Python's `rcan.encoding.canonical_json` returns the correct canonical bytes; the TS verifier was hashing the toString-of-Uint8Array, ~977 bytes vs the correct 280).

## How it was caught

Immediately after merging PR #89 and bootstrapping prod KV with cert-rig + cert-witness records for `bob-rig-2026` + `witness-bob-craigm`, an end-to-end smoke against `https://robotregistryfoundation.org/v2/cert-intake` with the Phase 4 prep keys returned 401 "rig signature did not verify against registered pub for kid bob-rig-2026". The Python signer was producing the correct bytes; the TS verifier was hashing the wrong ones.

## Fix

Drop the `TextEncoder.encode()` wrapper at four sites. The correct pattern is to consume `canonicalJson(...)` directly as bytes (Uint8Array is a BufferSource — Web Crypto accepts it without re-encoding). Same pattern already correctly used in `functions/v1/spatial-eval/_lib/score-canonical.ts:24`.

## Test plan

- [x] Vitest suite remains green (289 passing) — both sign and verify sides now use the correct bytes consistently.
- [ ] Re-run live prod smoke after merge: Python signer + TS verifier should produce 201 with `cert_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)