### PR TITLE
feat(v2/keys): /v2/keys/<kid> hybrid kid resolver endpoint

### DIFF
--- a/functions/v2/_lib/spki.test.ts
+++ b/functions/v2/_lib/spki.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { ed25519RawToPem, PEM_HEADER, PEM_FOOTER } from "./spki.js";
+
+describe("ed25519RawToPem", () => {
+  it("wraps 32 zero bytes in valid SPKI PEM", () => {
+    const raw = new Uint8Array(32);  // all zeros
+    const pem = ed25519RawToPem(raw);
+    expect(pem.startsWith(PEM_HEADER)).toBe(true);
+    expect(pem.trimEnd().endsWith(PEM_FOOTER)).toBe(true);
+    // The DER body is 12-byte prefix + 32 bytes raw = 44 bytes total.
+    // Base64-encoded: ceil(44/3)*4 = 60 chars (no padding needed since 44 is divisible by 4? Actually 44 % 3 = 2, so b64 = "...==")
+    const body = pem.slice(PEM_HEADER.length, pem.indexOf(PEM_FOOTER)).trim();
+    const der = Buffer.from(body, "base64");
+    expect(der.length).toBe(44);
+    // First 12 bytes are the fixed Ed25519 SPKI DER prefix
+    expect(Array.from(der.slice(0, 12))).toEqual([
+      0x30, 0x2A, 0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70, 0x03, 0x21, 0x00,
+    ]);
+    // Remaining 32 bytes are the raw key (all zeros in this test)
+    expect(Array.from(der.slice(12))).toEqual(new Array(32).fill(0));
+  });
+
+  it("rejects raw keys that are not exactly 32 bytes", () => {
+    expect(() => ed25519RawToPem(new Uint8Array(31))).toThrow(/32 bytes/);
+    expect(() => ed25519RawToPem(new Uint8Array(33))).toThrow(/32 bytes/);
+    expect(() => ed25519RawToPem(new Uint8Array(0))).toThrow(/32 bytes/);
+  });
+
+  it("known-vector: round-trips a real Ed25519 pubkey through the wrapper", async () => {
+    // Generate a real keypair via Web Crypto, export raw, wrap, then re-import via load_pem-like parse
+    const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]);
+    const spkiDer = await crypto.subtle.exportKey("spki", (kp as CryptoKeyPair).publicKey);
+    const rawBytes = new Uint8Array(spkiDer).slice(12);  // strip the 12-byte SPKI prefix Web Crypto gives us
+    expect(rawBytes.length).toBe(32);
+
+    const pem = ed25519RawToPem(rawBytes);
+    // Parse the PEM body back to DER and confirm it matches what Web Crypto exported
+    const body = pem.slice(PEM_HEADER.length, pem.indexOf(PEM_FOOTER)).trim();
+    const reDer = Buffer.from(body, "base64");
+    expect(Array.from(reDer)).toEqual(Array.from(new Uint8Array(spkiDer)));
+  });
+});

--- a/functions/v2/_lib/spki.ts
+++ b/functions/v2/_lib/spki.ts
@@ -1,0 +1,36 @@
+/**
+ * Ed25519 raw 32-byte public key → PKIX SubjectPublicKeyInfo PEM.
+ *
+ * RFC 8410 §4 specifies Ed25519 SPKI as a 12-byte DER prefix followed by
+ * the 32-byte raw key:
+ *   30 2A 30 05 06 03 2B 65 70 03 21 00 || raw[32]
+ *
+ * This is the exact shape Python's `cryptography.hazmat.primitives.serialization
+ * .load_pem_public_key()` expects for Ed25519 — confirmed by the deployed
+ * gateway's RRFResolverFromEnv code path.
+ */
+
+export const PEM_HEADER = "-----BEGIN PUBLIC KEY-----";
+export const PEM_FOOTER = "-----END PUBLIC KEY-----";
+
+const ED25519_SPKI_PREFIX = new Uint8Array([
+  0x30, 0x2A, 0x30, 0x05, 0x06, 0x03, 0x2B, 0x65, 0x70, 0x03, 0x21, 0x00,
+]);
+
+export function ed25519RawToPem(raw: Uint8Array): string {
+  if (raw.length !== 32) {
+    throw new Error(`Ed25519 raw pubkey must be 32 bytes, got ${raw.length}`);
+  }
+  const der = new Uint8Array(ED25519_SPKI_PREFIX.length + raw.length);
+  der.set(ED25519_SPKI_PREFIX, 0);
+  der.set(raw, ED25519_SPKI_PREFIX.length);
+  // Cloudflare Workers: btoa expects a binary string; build it from bytes.
+  let bin = "";
+  for (const b of der) bin += String.fromCharCode(b);
+  const b64 = btoa(bin);
+  // Standard PEM line-wrap at 64 chars (44 bytes → ~60 chars b64; one line is fine,
+  // but wrap defensively for any future caller passing larger inputs).
+  const lines: string[] = [];
+  for (let i = 0; i < b64.length; i += 64) lines.push(b64.slice(i, i + 64));
+  return `${PEM_HEADER}\n${lines.join("\n")}\n${PEM_FOOTER}\n`;
+}

--- a/functions/v2/_lib/types.ts
+++ b/functions/v2/_lib/types.ts
@@ -112,6 +112,7 @@ export type AuthorityPurpose =
   | "release-signing"
   | "attestation"
   | "policy"
+  | "operator-envelope"
   | "other";
 
 export interface AuthorityRecord {

--- a/functions/v2/authorities/register.ts
+++ b/functions/v2/authorities/register.ts
@@ -24,6 +24,7 @@ const ALLOWED_PURPOSES: AuthorityPurpose[] = [
   "release-signing",
   "attestation",
   "policy",
+  "operator-envelope",
   "other",
 ];
 

--- a/functions/v2/keys/[kid].test.ts
+++ b/functions/v2/keys/[kid].test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from "vitest";
+import { ed25519 } from "@noble/curves/ed25519.js";
+import { onRequest } from "./[kid].js";
+
+function b64(u8: Uint8Array): string {
+  return Buffer.from(u8).toString("base64");
+}
+
+function makeEnv(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
+  return {
+    env: {
+      RRF_KV: {
+        get: vi.fn(async (k: string) => store[k] ?? null),
+        put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+        list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+          keys: Object.keys(store).filter(k => k.startsWith(prefix)).map(name => ({ name })),
+          list_complete: true,
+        })),
+        delete: vi.fn(),
+      } as unknown as KVNamespace,
+    },
+    store,
+  };
+}
+
+function makeContext(env: unknown, params: Record<string, string>, method = "GET") {
+  return {
+    request: new Request(`https://example.test/v2/keys/${params.kid}`, { method }),
+    env,
+    params,
+    waitUntil: () => {},
+    next: async () => new Response(),
+    data: {},
+    functionPath: "/v2/keys/[kid]",
+  } as unknown as Parameters<typeof onRequest>[0];
+}
+
+function setupValidAuthority(store: Record<string, string>, kid = "bob-operator-2026") {
+  const ed25519Priv = crypto.getRandomValues(new Uint8Array(32));
+  const ed25519Pub = ed25519.getPublicKey(ed25519Priv);
+  const pqPub = crypto.getRandomValues(new Uint8Array(1952));
+  const pqKid = "deadbeef";
+
+  const ran = "RAN-000000000019";
+  store[`kid:${kid}:2026-05-04T15:00:00.000Z`] = JSON.stringify({
+    ran,
+    valid_from: "2026-05-04T00:00:00.000Z",
+    registered_at: "2026-05-04T15:00:00.000Z",
+    registered_by: "RAN-000000000018",
+  });
+  store[`authority:${ran}`] = JSON.stringify({
+    ran,
+    organization: "OpenCastor",
+    display_name: "bob-operator-2026 — Phase 5 INVOKE signer for Bob",
+    purpose: "operator-envelope",
+    signing_pub: b64(ed25519Pub),
+    pq_signing_pub: b64(pqPub),
+    pq_kid: pqKid,
+    signing_alg: ["Ed25519", "ML-DSA-65"],
+    registered_at: "2026-05-04T15:00:00.000Z",
+    status: "active",
+  });
+  return { ed25519Pub, pqPub, pqKid, ran };
+}
+
+describe("GET /v2/keys/<kid>", () => {
+  it("returns 200 with hybrid response shape on a valid active kid", async () => {
+    const { env, store } = makeEnv();
+    const { ed25519Pub, pqPub, pqKid, ran } = setupValidAuthority(store);
+    const res = await onRequest(makeContext(env, { kid: "bob-operator-2026" }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.kid).toBe("bob-operator-2026");
+    expect(body.alg).toBe("Ed25519");
+    expect(body.public_key_pem).toMatch(/^-----BEGIN PUBLIC KEY-----\n[A-Za-z0-9+/=\n]+-----END PUBLIC KEY-----\n$/);
+    expect(body.pq_alg).toBe("ML-DSA-65");
+    expect(body.pq_public_key_b64).toBe(b64(pqPub));
+    expect(body.pq_kid).toBe(pqKid);
+    expect(body.ran).toBe(ran);
+    expect(body.status).toBe("active");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=60");
+  });
+
+  it("returns 404 when the kid has no records at all", async () => {
+    const { env } = makeEnv();
+    const res = await onRequest(makeContext(env, { kid: "nobody-2099" }));
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("kid not registered");
+    expect(body.kid).toBe("nobody-2099");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("returns 404 when kid records exist but none cover NOW", async () => {
+    const { env, store } = makeEnv();
+    setupValidAuthority(store);
+    store["kid:bob-operator-2026:2026-05-04T15:00:00.000Z"] = JSON.stringify({
+      ran: "RAN-000000000019",
+      valid_from: "2020-01-01T00:00:00.000Z",
+      valid_until: "2020-12-31T23:59:59.999Z",
+      registered_at: "2020-01-01T00:00:00.000Z",
+      registered_by: "RAN-000000000018",
+    });
+    const res = await onRequest(makeContext(env, { kid: "bob-operator-2026" }));
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("kid has no valid mapping at this time");
+  });
+
+  it("returns 410 when the authority has status: revoked", async () => {
+    const { env, store } = makeEnv();
+    const { ran } = setupValidAuthority(store);
+    const auth = JSON.parse(store[`authority:${ran}`]);
+    auth.status = "revoked";
+    auth.revoked_at = "2026-05-04T16:00:00.000Z";
+    auth.revocation_reason = "operator key rotation";
+    store[`authority:${ran}`] = JSON.stringify(auth);
+    const res = await onRequest(makeContext(env, { kid: "bob-operator-2026" }));
+    expect(res.status).toBe(410);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("kid revoked");
+    expect(body.revoked_at).toBe("2026-05-04T16:00:00.000Z");
+    expect(body.revocation_reason).toBe("operator key rotation");
+  });
+
+  it("returns 502 when signing_pub is not 32 bytes", async () => {
+    const { env, store } = makeEnv();
+    const { ran } = setupValidAuthority(store);
+    const auth = JSON.parse(store[`authority:${ran}`]);
+    auth.signing_pub = b64(new Uint8Array(31));
+    store[`authority:${ran}`] = JSON.stringify(auth);
+    const res = await onRequest(makeContext(env, { kid: "bob-operator-2026" }));
+    expect(res.status).toBe(502);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("registry data integrity error");
+  });
+
+  it("returns 502 when pq_signing_pub is not 1952 bytes", async () => {
+    const { env, store } = makeEnv();
+    const { ran } = setupValidAuthority(store);
+    const auth = JSON.parse(store[`authority:${ran}`]);
+    auth.pq_signing_pub = b64(new Uint8Array(100));
+    store[`authority:${ran}`] = JSON.stringify(auth);
+    const res = await onRequest(makeContext(env, { kid: "bob-operator-2026" }));
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 when authority record is unparseable JSON", async () => {
+    const { env, store } = makeEnv();
+    const { ran } = setupValidAuthority(store);
+    store[`authority:${ran}`] = "{ not json";
+    const res = await onRequest(makeContext(env, { kid: "bob-operator-2026" }));
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 405 on non-GET methods", async () => {
+    const { env } = makeEnv();
+    const res = await onRequest(makeContext(env, { kid: "bob-operator-2026" }, "POST"));
+    expect(res.status).toBe(405);
+  });
+
+  it("most-recent registered_at wins when multiple kid mappings cover NOW", async () => {
+    const { env, store } = makeEnv();
+    setupValidAuthority(store);  // creates kid:bob-operator-2026:2026-05-04T15:00:00.000Z → RAN-019
+
+    const ed25519Priv2 = crypto.getRandomValues(new Uint8Array(32));
+    const ed25519Pub2 = ed25519.getPublicKey(ed25519Priv2);
+    const pqPub2 = crypto.getRandomValues(new Uint8Array(1952));
+    store["authority:RAN-000000000020"] = JSON.stringify({
+      ran: "RAN-000000000020",
+      organization: "OpenCastor",
+      display_name: "bob-operator-2026 (rotated)",
+      purpose: "operator-envelope",
+      signing_pub: b64(ed25519Pub2),
+      pq_signing_pub: b64(pqPub2),
+      pq_kid: "cafef00d",
+      signing_alg: ["Ed25519", "ML-DSA-65"],
+      registered_at: "2026-05-04T16:00:00.000Z",
+      status: "active",
+    });
+    store["kid:bob-operator-2026:2026-05-04T16:00:00.000Z"] = JSON.stringify({
+      ran: "RAN-000000000020",
+      valid_from: "2026-05-04T15:30:00.000Z",
+      registered_at: "2026-05-04T16:00:00.000Z",
+      registered_by: "RAN-000000000018",
+    });
+
+    const res = await onRequest(makeContext(env, { kid: "bob-operator-2026" }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.ran).toBe("RAN-000000000020");
+    expect(body.pq_kid).toBe("cafef00d");
+  });
+});

--- a/functions/v2/keys/[kid].ts
+++ b/functions/v2/keys/[kid].ts
@@ -1,0 +1,162 @@
+/**
+ * GET /v2/keys/<kid> — resolve a kid to its registered hybrid pubkey pair.
+ *
+ * Bridges robot-md-gateway's RRFResolverFromEnv to the existing kid:/authority:
+ * KV registry. Returns Ed25519 PEM (gateway reads this today) plus ML-DSA-65
+ * raw base64 + pq_kid (forward-compat for hybrid verifiers).
+ *
+ * Spec: docs/superpowers/specs/2026-05-04-rrf-keys-endpoint-design.md
+ * Plan: docs/superpowers/plans/2026-05-04-rrf-keys-endpoint.md (Task A4)
+ *
+ * Note: this handler does NOT delegate to resolveKidToAuthority because that
+ * helper collapses "authority record unparseable" into "null" — losing the
+ * 502-vs-404 distinction this endpoint needs. We inline a single-pass scan
+ * over kid:<kid>:* that selects the most-recent registered_at covering NOW,
+ * then fetches the authority record explicitly so we can surface parse
+ * failures as 502 (registry data integrity error) rather than 404.
+ */
+
+import { ed25519RawToPem } from "../_lib/spki.js";
+
+interface AuthorityForRead {
+  ran: `RAN-${string}`;
+  organization?: string;
+  display_name?: string;
+  purpose?: string;
+  signing_pub: string;
+  pq_signing_pub: string;
+  pq_kid: string;
+  signing_alg?: string[];
+  registered_at?: string;
+  status?: "active" | "revoked";
+  revoked_at?: string;
+  revocation_reason?: string;
+}
+
+interface KidMappingForRead {
+  ran: `RAN-${string}`;
+  valid_from: string;
+  valid_until?: string;
+  registered_at: string;
+  registered_by?: string;
+}
+
+const NO_STORE = { "Content-Type": "application/json", "Cache-Control": "no-store" };
+
+function jsonResponse(status: number, body: unknown, headers: Record<string, string> = NO_STORE): Response {
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+export const onRequest: PagesFunction<{ RRF_KV: KVNamespace }, "kid"> = async ({ request, env, params }) => {
+  if (request.method !== "GET") {
+    return jsonResponse(405, { error: "Method not allowed" });
+  }
+  const kid = String(params.kid ?? "");
+  if (!kid) {
+    return jsonResponse(404, { error: "kid not registered", kid });
+  }
+
+  // Single-pass scan of kid:<kid>:* — find the most-recent registered_at
+  // mapping that covers NOW.
+  let listResult;
+  try {
+    listResult = await env.RRF_KV.list({ prefix: `kid:${kid}:` });
+  } catch {
+    return jsonResponse(502, { error: "registry temporarily unavailable" });
+  }
+  if (listResult.keys.length === 0) {
+    return jsonResponse(404, { error: "kid not registered", kid });
+  }
+
+  const nowMs = Date.now();
+  type Cand = { mapping: KidMappingForRead; key: string };
+  const candidates: Cand[] = [];
+  for (const k of listResult.keys) {
+    let raw: string | null;
+    try {
+      raw = await env.RRF_KV.get(k.name, "text");
+    } catch {
+      return jsonResponse(502, { error: "registry temporarily unavailable" });
+    }
+    if (!raw) continue;
+    let mapping: KidMappingForRead;
+    try {
+      mapping = JSON.parse(raw) as KidMappingForRead;
+    } catch {
+      // Skip a single corrupt mapping — other versions may still be valid.
+      continue;
+    }
+    const fromMs = Date.parse(mapping.valid_from);
+    const untilMs = mapping.valid_until ? Date.parse(mapping.valid_until) : Number.POSITIVE_INFINITY;
+    if (Number.isNaN(fromMs)) continue;
+    if (nowMs < fromMs) continue;
+    if (nowMs >= untilMs) continue;
+    candidates.push({ mapping, key: k.name });
+  }
+  if (candidates.length === 0) {
+    return jsonResponse(404, { error: "kid has no valid mapping at this time", kid });
+  }
+  // Lexicographic ISO-8601 sort = chronological; most-recent registered_at wins.
+  candidates.sort((a, b) => b.mapping.registered_at.localeCompare(a.mapping.registered_at));
+  const winner = candidates[0].mapping;
+
+  // Fetch the authority record. Distinguish missing (404) from unparseable (502).
+  let authRaw: string | null;
+  try {
+    authRaw = await env.RRF_KV.get(`authority:${winner.ran}`, "text");
+  } catch {
+    return jsonResponse(502, { error: "registry temporarily unavailable" });
+  }
+  if (!authRaw) {
+    return jsonResponse(404, { error: "kid has no valid mapping at this time", kid });
+  }
+
+  let auth: AuthorityForRead;
+  try {
+    auth = JSON.parse(authRaw) as AuthorityForRead;
+  } catch {
+    return jsonResponse(502, { error: "registry data integrity error" });
+  }
+
+  if (auth.status === "revoked") {
+    const body: Record<string, unknown> = { error: "kid revoked", kid, ran: auth.ran };
+    if (auth.revoked_at) body.revoked_at = auth.revoked_at;
+    if (auth.revocation_reason) body.revocation_reason = auth.revocation_reason;
+    return jsonResponse(410, body);
+  }
+
+  let edRaw: Uint8Array;
+  let pqRaw: Uint8Array;
+  try {
+    edRaw = Uint8Array.from(atob(auth.signing_pub), c => c.charCodeAt(0));
+    pqRaw = Uint8Array.from(atob(auth.pq_signing_pub), c => c.charCodeAt(0));
+  } catch {
+    return jsonResponse(502, { error: "registry data integrity error" });
+  }
+  if (edRaw.length !== 32 || pqRaw.length !== 1952) {
+    return jsonResponse(502, { error: "registry data integrity error" });
+  }
+  if (!auth.pq_kid || typeof auth.pq_kid !== "string") {
+    return jsonResponse(502, { error: "registry data integrity error" });
+  }
+
+  let publicKeyPem: string;
+  try {
+    publicKeyPem = ed25519RawToPem(edRaw);
+  } catch {
+    return jsonResponse(502, { error: "registry data integrity error" });
+  }
+
+  return jsonResponse(200, {
+    kid,
+    alg: "Ed25519",
+    public_key_pem: publicKeyPem,
+    pq_alg: "ML-DSA-65",
+    pq_public_key_b64: auth.pq_signing_pub,
+    pq_kid: auth.pq_kid,
+    ran: auth.ran,
+    valid_from: winner.valid_from,
+    valid_until: winner.valid_until ?? null,
+    status: "active",
+  }, { "Content-Type": "application/json", "Cache-Control": "public, max-age=60" });
+};

--- a/scripts/register-operator-kid.ts
+++ b/scripts/register-operator-kid.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env tsx
+/**
+ * Generate a kid:<kid>:<registered_at> + authority:<ran> KV record pair for
+ * `wrangler kv bulk put`.
+ *
+ * Plan 6 Phase 5 addendum — registers a hybrid Ed25519 + ML-DSA-65 operator kid
+ * (e.g., bob-operator-2026 → RAN-000000000019) so /v2/keys/<kid> can resolve
+ * envelope signatures against it.
+ *
+ * Mirrors register-aggregator-kid.ts shape; adds authority-record fields per
+ * the AuthorityRecord type in functions/v2/_lib/types.ts.
+ *
+ * Usage:
+ *   tsx scripts/register-operator-kid.ts \
+ *     --kid bob-operator-2026 \
+ *     --ran RAN-000000000019 \
+ *     --signing-pub-b64 <ed25519-raw-32-byte-b64> \
+ *     --pq-signing-pub-b64 <ml-dsa-65-raw-1952-byte-b64> \
+ *     --pq-kid <8-hex sha256(pq-pub)[:8]> \
+ *     --organization OpenCastor \
+ *     --display-name "bob-operator-2026 — Phase 5 INVOKE signer for Bob" \
+ *     --purpose operator-envelope \
+ *     --registered-by RAN-000000000018 \
+ *     --valid-from 2026-05-04T15:00:00Z \
+ *     [--valid-until 2027-05-04T00:00:00Z] \
+ *     [--out /tmp/operator-kid.json]
+ */
+
+function arg(name: string, required = true): string | undefined {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) {
+    if (required) {
+      console.error(`Missing --${name}`);
+      process.exit(2);
+    }
+    return undefined;
+  }
+  return process.argv[idx + 1];
+}
+
+function fail(msg: string): never {
+  console.error(`error: ${msg}`);
+  process.exit(2);
+}
+
+const kid = arg("kid")!;
+const ran = arg("ran")!;
+const signingPubB64 = arg("signing-pub-b64")!;
+const pqSigningPubB64 = arg("pq-signing-pub-b64")!;
+const pqKid = arg("pq-kid")!;
+const organization = arg("organization")!;
+const displayName = arg("display-name")!;
+const purpose = arg("purpose")!;
+const registeredBy = arg("registered-by")!;
+const validFrom = arg("valid-from")!;
+const validUntil = arg("valid-until", false);
+const out = arg("out", false);
+
+if (!/^RAN-\d{12}$/.test(ran)) fail(`--ran must match RAN-NNNNNNNNNNNN; got ${ran}`);
+if (!/^RAN-\d{12}$/.test(registeredBy)) fail(`--registered-by must match RAN-NNNNNNNNNNNN; got ${registeredBy}`);
+if (!/^[0-9a-f]{8}$/.test(pqKid)) fail(`--pq-kid must be 8 hex chars; got ${pqKid}`);
+
+let edBytes: Buffer;
+try { edBytes = Buffer.from(signingPubB64, "base64"); } catch { fail("--signing-pub-b64 is not valid base64"); }
+if (edBytes.length !== 32) fail(`--signing-pub-b64 must decode to 32 bytes (Ed25519); got ${edBytes.length}`);
+
+let pqBytes: Buffer;
+try { pqBytes = Buffer.from(pqSigningPubB64, "base64"); } catch { fail("--pq-signing-pub-b64 is not valid base64"); }
+if (pqBytes.length !== 1952) fail(`--pq-signing-pub-b64 must decode to 1952 bytes (ML-DSA-65); got ${pqBytes.length}`);
+
+const registeredAt = new Date().toISOString();
+
+const kidMapping: Record<string, unknown> = {
+  ran,
+  valid_from: validFrom,
+  registered_at: registeredAt,
+  registered_by: registeredBy,
+};
+if (validUntil) kidMapping["valid_until"] = validUntil;
+
+const authority: Record<string, unknown> = {
+  ran,
+  organization,
+  display_name: displayName,
+  purpose,
+  signing_pub: signingPubB64,
+  pq_signing_pub: pqSigningPubB64,
+  pq_kid: pqKid,
+  signing_alg: ["Ed25519", "ML-DSA-65"],
+  registered_at: registeredAt,
+  status: "active",
+};
+
+const bulkRecord = [
+  { key: `kid:${kid}:${registeredAt}`, value: JSON.stringify(kidMapping) },
+  { key: `authority:${ran}`, value: JSON.stringify(authority) },
+];
+
+const text = JSON.stringify(bulkRecord, null, 2);
+if (out) {
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(out, text);
+  console.error(`wrote ${out}`);
+} else {
+  process.stdout.write(text + "\n");
+}

--- a/tests/register-operator-kid.test.ts
+++ b/tests/register-operator-kid.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
+const SCRIPT = resolve(__dirname, "..", "scripts", "register-operator-kid.ts");
+
+function runOk(args: string[]): { kvBulk: Array<{ key: string; value: string }> } {
+  const stdout = execFileSync("npx", ["tsx", SCRIPT, ...args], { encoding: "utf-8" });
+  const kvBulk = JSON.parse(stdout);
+  return { kvBulk };
+}
+
+function runFail(args: string[]): { stderr: string; status: number } {
+  try {
+    execFileSync("npx", ["tsx", SCRIPT, ...args], { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+    return { stderr: "", status: 0 };
+  } catch (e: unknown) {
+    const err = e as { stderr?: Buffer; status?: number };
+    return { stderr: err.stderr?.toString() ?? "", status: err.status ?? 1 };
+  }
+}
+
+const VALID_ARGS = [
+  "--kid", "bob-operator-2026",
+  "--ran", "RAN-000000000019",
+  "--signing-pub-b64", Buffer.from(new Uint8Array(32)).toString("base64"),
+  "--pq-signing-pub-b64", Buffer.from(new Uint8Array(1952)).toString("base64"),
+  "--pq-kid", "deadbeef",
+  "--organization", "OpenCastor",
+  "--display-name", "bob-operator-2026 — Phase 5 INVOKE signer for Bob",
+  "--purpose", "operator-envelope",
+  "--registered-by", "RAN-000000000018",
+  "--valid-from", "2026-05-04T15:00:00.000Z",
+];
+
+describe("register-operator-kid.ts", () => {
+  it("emits a kid:<kid>:<ts> + authority:<ran> bulk-put pair on valid args", () => {
+    const { kvBulk } = runOk(VALID_ARGS);
+    expect(kvBulk).toHaveLength(2);
+    const kidRecord = kvBulk.find(r => r.key.startsWith("kid:bob-operator-2026:"));
+    const authRecord = kvBulk.find(r => r.key === "authority:RAN-000000000019");
+    expect(kidRecord).toBeDefined();
+    expect(authRecord).toBeDefined();
+    const kidVal = JSON.parse(kidRecord!.value);
+    expect(kidVal.ran).toBe("RAN-000000000019");
+    expect(kidVal.valid_from).toBe("2026-05-04T15:00:00.000Z");
+    expect(kidVal.registered_by).toBe("RAN-000000000018");
+    const authVal = JSON.parse(authRecord!.value);
+    expect(authVal.ran).toBe("RAN-000000000019");
+    expect(authVal.organization).toBe("OpenCastor");
+    expect(authVal.purpose).toBe("operator-envelope");
+    expect(authVal.signing_alg).toEqual(["Ed25519", "ML-DSA-65"]);
+    expect(authVal.status).toBe("active");
+    expect(authVal.signing_pub.length).toBeGreaterThan(0);
+    expect(authVal.pq_signing_pub.length).toBeGreaterThan(0);
+    expect(authVal.pq_kid).toBe("deadbeef");
+  });
+
+  it("rejects an Ed25519 pubkey that doesn't decode to 32 bytes", () => {
+    const args = [...VALID_ARGS];
+    const idx = args.indexOf("--signing-pub-b64");
+    args[idx + 1] = Buffer.from(new Uint8Array(31)).toString("base64");
+    const { stderr, status } = runFail(args);
+    expect(status).not.toBe(0);
+    expect(stderr).toMatch(/32 bytes/);
+  });
+
+  it("rejects an ML-DSA-65 pubkey that doesn't decode to 1952 bytes", () => {
+    const args = [...VALID_ARGS];
+    const idx = args.indexOf("--pq-signing-pub-b64");
+    args[idx + 1] = Buffer.from(new Uint8Array(100)).toString("base64");
+    const { stderr, status } = runFail(args);
+    expect(status).not.toBe(0);
+    expect(stderr).toMatch(/1952 bytes/);
+  });
+
+  it("rejects a malformed RAN", () => {
+    const args = [...VALID_ARGS];
+    const idx = args.indexOf("--ran");
+    args[idx + 1] = "not-a-ran";
+    const { stderr, status } = runFail(args);
+    expect(status).not.toBe(0);
+    expect(stderr).toMatch(/RAN-/);
+  });
+
+  it("rejects an 8-hex pq_kid that's not 8 hex chars", () => {
+    const args = [...VALID_ARGS];
+    const idx = args.indexOf("--pq-kid");
+    args[idx + 1] = "deadbeef99";
+    const { stderr, status } = runFail(args);
+    expect(status).not.toBe(0);
+    expect(stderr).toMatch(/pq-kid/);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /v2/keys/<kid>` endpoint that bridges robot-md-gateway's `RRFResolverFromEnv` to the existing `kid:`/`authority:` KV registry.
- Returns hybrid pubkey shape: `public_key_pem` (Ed25519, gateway reads today) + `pq_public_key_b64` + `pq_kid` (ML-DSA-65, forward-compat).
- Adds `register-operator-kid.ts` — KV bulk-record generator for hybrid operator authorities.
- One-line `AuthorityPurpose` enum extension to add `"operator-envelope"`, plus matching runtime allowlist update.
- Adds `spki.ts` helper for Ed25519 raw → PEM SPKI wrap.

Unblocks Plan 6 Phase 5 of the cert-tracks plan: the gateway has been silently rejecting every signed INVOKE because this endpoint didn't exist. Once merged + deployed + bob-operator-2026 registered, Phase 5 resumes.

## Test plan
- [ ] `npm test` passes (full vitest suite green; expect 306/306)
- [ ] `curl https://robotregistryfoundation.org/v2/keys/bob-operator-2026` returns 200 with both keys after registration (Task A7)
- [ ] Python loopback: `cryptography.serialization.load_pem_public_key(<curl output>.public_key_pem.encode())` doesn't raise
- [ ] Phase 5 smoke run (5+1) passes against the deployed endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)