### PR TITLE
docs: retire OpenCastor "reference implementation" framing + L1-L5 → L1-L4 (Plan 9 Phase 2)

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -83,7 +83,7 @@
           </li>
           <li>
             <a href="https://opencastor.com" target="_blank" rel="noopener noreferrer" class="text-sm text-text-muted hover:text-accent transition-colors flex items-center gap-1">
-              OpenCastor — RCAN reference implementation
+              OpenCastor — RCAN runtime
               <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
             </a>
           </li>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -29,7 +29,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
           a navigation stack with a Hailo-8 NPU and an OAK-D camera. When Bob needed to identify itself to other
           systems and be registered somewhere, it became clear there was nowhere independent to register it.
           <a href="https://opencastor.com" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">OpenCastor</a>
-          is the open-source RCAN reference implementation that powers robots like Bob.
+          is the open-source RCAN runtime that powers robots like Bob.
         </p>
         <p>
           Building the registration system led to the <a href="https://rcan.dev" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">RCAN protocol specification</a> —
@@ -122,20 +122,19 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
       </div>
     </section>
 
-    <!-- RCAN Reference Implementation -->
+    <!-- RCAN Runtime — OpenCastor -->
     <section class="mb-12">
-      <h2 class="font-display text-2xl font-semibold text-text mb-4 pb-2 border-b border-border">RCAN Reference Implementation</h2>
+      <h2 class="font-display text-2xl font-semibold text-text mb-4 pb-2 border-b border-border">OpenCastor — RCAN Runtime</h2>
       <div class="flex flex-col md:flex-row gap-6 p-6 bg-bg-card border border-border rounded-xl">
         <div class="flex-1">
           <p class="text-text-muted leading-relaxed mb-3">
             <a href="https://opencastor.com" target="_blank" rel="noopener noreferrer"
                class="font-semibold text-accent hover:underline">OpenCastor</a>
-            is the open-source reference implementation of the RCAN protocol.
-            It is the runtime that powers registered robots like Bob and Alex, and was the proving ground for
-            the registry and RRN system now governed by this Foundation.
+            is the open-source RCAN runtime. It powers registered robots like Bob and Alex,
+            and was the proving ground for the registry and RRN system now governed by this Foundation.
           </p>
           <ul class="text-sm text-text-muted space-y-1">
-            <li>• Full <a href="https://rcan.dev/compatibility" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">RCAN protocol</a> conformance (L1–L5) · RRN/RCN/RMN/RHN entity registration</li>
+            <li>• Full <a href="https://rcan.dev/compatibility" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">RCAN protocol</a> conformance (L1–L4) · RRN/RCN/RMN/RHN entity registration</li>
             <li>• Robot Registration Number (RRN) minting and validation</li>
             <li>• Tiered AI brain with provider fallback</li>
             <li>• Fleet management, telemetry, and federated swarms</li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -30,7 +30,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <p class="text-sm text-text-muted/70 max-w-xl mx-auto mt-3">
       RCAN is optional — register any robot, any stack, without it.
       RCAN adds cryptographic ML-DSA-65 identity and higher verification tiers when you need them.
-      <a href="https://opencastor.com" class="text-accent/80 hover:underline">OpenCastor</a> is the open-source RCAN reference implementation.
+      <a href="https://opencastor.com" class="text-accent/80 hover:underline">OpenCastor</a> is the open-source RCAN runtime.
       <a href="https://docs.robotregistryfoundation.org/rcan-integration/" class="text-accent/80 hover:underline">How RCAN &amp; RRF work together →</a>
     </p>
     <p class="text-sm text-text-muted/70 max-w-xl mx-auto mt-3">


### PR DESCRIPTION
## Summary

Plan 9 Phase 2 RRF apex single-fix PR: applies the six factual findings from
[`operations/2026-05-05-apex-text-accuracy/findings-rrf.md`](https://github.com/craigm26/opencastor-ops/blob/master/operations/2026-05-05-apex-text-accuracy/findings-rrf.md)
in the opencastor-ops audit repo.

The Phase 2 audit covered 12 files (6 pages + 5 components + 1 layout) and
produced six factual findings — five F-01-pattern semantic blind-spots plus
one conformance-level number drift. Forbidden-phrase lint reports `0 hits`
on this repo; every finding slips the existing regex.

## Findings landed in this PR

- **[F-RRF-01]** `src/pages/index.astro:33` — Apex hero subtitle: "OpenCastor is the open-source RCAN reference implementation." → "OpenCastor is the open-source RCAN runtime."
- **[F-RRF-02]** `src/pages/about/index.astro:31-32` — Origin section: same retired framing replaced.
- **[F-RRF-03]** `src/pages/about/index.astro:125, 127` — Section heading + HTML comment: "RCAN Reference Implementation" → "OpenCastor — RCAN Runtime". Astro emits HTML comments to production output, so the comment is also user-visible.
- **[F-RRF-04]** `src/pages/about/index.astro:131-133` — Section paragraph: "open-source reference implementation of the RCAN protocol" → "open-source RCAN runtime". The "of the RCAN protocol" insertion of "the" is the variant that slipped the lint regex `reference implementation of RCAN`.
- **[F-RRF-05]** `src/pages/about/index.astro:138` — Conformance levels: "(L1–L5)" → "(L1–L4)". Per canonical strategy §2 Decision 4 (normative-now) and live `rcan.dev/conformance/` (verified `curl` 2026-05-08), protocol conformance is L1–L4. L5 only survives on allowlisted v2.2/v2.3 spec-snapshot pages.
- **[F-RRF-06]** `src/components/SiteFooter.astro:86` — Site-wide footer ecosystem link: "OpenCastor — RCAN reference implementation" → "OpenCastor — RCAN runtime".

All five F-01-pattern findings adopt the canonical Layer-4 description ("RCAN runtime") per spec §3 Decision 2 and the canonical strategy doc §3 silo charters. RCAN-the-protocol is implementation-independent; OpenCastor is one of multiple ways to implement it (per-spec) and the runtime that productizes the open-core kernel (per-strategy §3).

## Stylistic-only findings deferred

Two sub-findings are **deferred to a follow-up issue** (filed separately) because they are dead-code today:

- **[S-RRF-A]** `src/components/VerificationBadge.astro` Props enum (`community | verified | certified | accredited`) drifts from the rest of the system (`community | verified | manufacturer | certified` in `RobotCard.astro`, `[rrn].astro`, and `CLAUDE.md`). `VerificationBadge` is consumed only by `RobotCard.astro` (unused — `grep -rn "RobotCard" src/` returns no consumers) and `[rrn].astro` (generates 0 static paths because `src/content/robots/` is empty).
- **[S-RRF-B]** `src/pages/registry/[rrn].astro:232` says `'Full conformance audit passed. RCAN L1/L2/L3 certified.'` — should align with L1–L4 (per F-RRF-05) and the canonical certification disclaimer ("conformance is self-asserted via signed bundles, independently replayable from those bundles" — the word "certified" needs replacement). Same dead-code-today caveat.

Both ship live the moment a single robot JSON lands in `src/content/robots/`.

## Phase 1 sibling PR (carryover)

This PR's sibling is [continuonai/rcan-spec#210](https://github.com/continuonai/rcan-spec/pull/210), which lands the Plan 9 Phase 1 finding (F-01) on the rcan.dev about page. Same retired-framing pattern, same Plan 9 work block. The two PRs are independent (different repos) and either can merge first.

## Verification

- [x] `python3 tools/lint_forbidden_phrases.py --dict docs/standards/forbidden-phrases.json --root ~/RobotRegistryFoundation` exits 0 (0 hits).
- [x] `npm run build` — 5 pages built clean (the empty content collection warning is pre-existing — `src/content/robots/` is intentionally empty per the dynamic registry redesign documented in `[rrn].astro:1-7`).
- [x] `npm run test` — 306/306 vitest tests pass across 44 test files.
- [x] `grep -rn "reference implementation\|L1–L5\|L1-L5" src/` — no results.
- [x] Manual diff review — 3 files changed, 8 insertions, 9 deletions (net –1, one paragraph rewrap).

## Spec / Plan references

- North star: [`docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md`](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md) §3 Decision 2 (retire "reference implementation of RCAN" framing) + §2 Decision 4 (L1–L4 protocol conformance, normative-now)
- Canonical strategy: [`business/2026-05-08-strategy-canonical.md`](https://github.com/craigm26/opencastor-ops/blob/master/business/2026-05-08-strategy-canonical.md) §3 (Layer 4 silo charter for OpenCastor; Layer 6 silo charter for RRF)
- Forbidden-phrase dict: [`docs/standards/forbidden-phrases.json`](https://github.com/craigm26/opencastor-ops/blob/master/docs/standards/forbidden-phrases.json) — `reference-implementation-of-rcan` regex, which the F-01-pattern variants here all slip
- Plan 8 redirects: `public/_redirects` — confirms apex retains only `/registry/*` + `/about/`; all migrated prose pages already point to `https://docs.robotregistryfoundation.org/` full URLs in code, so this PR does not touch link targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)