### PR TITLE
docs(claude-md): retire "reference impl" framing + bump stale versions (Plan 9 carryover)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,8 @@ Each robot in `src/content/robots/` must have:
   },
   "verification_status": "community | verified | manufacturer | certified",
   "ruri": "rcan://host:port/robot-id",
-  "rcan_version": "1.4",
-  "opencastor_version": "2026.3.13.11",
+  "rcan_version": "3.2",
+  "opencastor_version": "see PyPI",
   "tags": ["..."],
   "submitted_by": "github-username",
   "submitted_date": "YYYY-MM-DD",
@@ -99,7 +99,7 @@ git push origin main  # Triggers Cloudflare Pages deploy
 ## Key Cross-References
 
 - RCAN spec §21 (Registry Integration): https://rcan.dev/spec/section-21/
-- OpenCastor (reference impl): https://opencastor.com
+- OpenCastor (productized open-core RCAN runtime, Layer 4 per spec §3): https://opencastor.com
 - rcan.dev (RRN authority): https://rcan.dev
 
 ## When Updating Registered Robots
@@ -108,6 +108,6 @@ Always update both:
 1. `src/content/robots/<robot-slug>.json` — the JSON data
 2. If OpenCastor version changes: update `opencastor_version` and `rcan_version` fields
 
-Current registered robots:
-- **Bob** (`opencastor-bob.json`): RRN-000000000001, Raspberry Pi 5 + Hailo-8, OpenCastor v2026.3.13.11
-- **Alex** (`opencastor-alex.json`): RRN-000000000005, Raspberry Pi 5 + OAK-D, OpenCastor v2026.3.13.11
+Current registered robots (versions per the live `/v2/registry` API; `src/content/robots/` is intentionally empty since the registry was redesigned to dynamic — see `[rrn].astro:1-7`):
+- **Bob**: RRN-000000000001, Raspberry Pi 5 + Hailo-8 + SO-ARM101 6-DOF arm, OpenCastor (see PyPI for canonical version)
+- **Alex**: RRN-000000000005, Raspberry Pi 5 + OAK-D, OpenCastor (see PyPI for canonical version)


### PR DESCRIPTION
## Summary

Plan 9 [lessons-learned](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/lessons-learned/2026-05-08-plan-9-execution.md) open question §4 (cross-repo CLAUDE.md drift sweep). 3 distinct drifts in this repo's CLAUDE.md.

## Diff

| Lines | Drift | Severity |
|---|---|---|
| 56-57 | JSON schema example: `rcan_version: "1.4"` + `opencastor_version: "2026.3.13.11"` | Stale (drift) |
| 102 | `OpenCastor (reference impl)` | **F-01 PATTERN — factual** (Decision 2 retired "reference implementation" framing) |
| 112-113 | `Current registered robots: ... OpenCastor v2026.3.13.11` × 2 | Stale + ref to `src/content/robots/` JSON files which are now empty (registry redesigned to dynamic API per Phase 2 audit) |

## Fix details

- **F-01-pattern (line 102):** Same retired-framing fixed across Plan 9 Phase 1-5. Replaced with canonical Layer-4 charter from spec §3.
- **JSON schema example (lines 56-57):** Bumped to `"3.2"` (matches `rcan_spec_version` in `opencastor-ops/config/repos.json`); `opencastor_version` left as "see PyPI" since the [versioning-scheme conflict (S-OCD-D)](https://github.com/craigm26/OpenCastor/issues/895) is unresolved.
- **Current registered robots (lines 112-113):** Removed pinned versions (operator updates lag canonical state); added clarifying note that `src/content/robots/` is intentionally empty since the registry was redesigned to a dynamic `/v2/registry` API (per Phase 2 audit finding — `[rrn].astro` generates 0 static paths).

## Sister PRs (same Plan-9-carryover drift class)

- `craigm26/opencastor-ops` master `f9bfd1b` (direct commit)
- [craigm26/opencastor-client#132](https://github.com/craigm26/opencastor-client/pull/132)
- [craigm26/OpenCastor#896](https://github.com/craigm26/OpenCastor/pull/896)
- [continuonai/rcan-py#61](https://github.com/continuonai/rcan-py/pull/61)
- [continuonai/rcan-ts#52](https://github.com/continuonai/rcan-ts/pull/52)

## Note on JSON-schema-example doc structure

The "Robot JSON Schema" + "When Updating Registered Robots" sections of CLAUDE.md document a static-JSON workflow that is no longer how the registry works (the redesign to dynamic API happened post-CLAUDE.md authoring; this surfaced during Plan 9 Phase 2 audit). A larger restructuring of those sections to reflect the dynamic-API reality is **NOT in this PR** — that's a content task that benefits from operator review of the actual registry implementation. This PR only fixes the mechanically-stale versions + the F-01 framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)