### PR TITLE
feat(packages): /v2/packages/[rpn]/proof — return original signed register body

### DIFF
--- a/functions/v2/packages/[rpn]/proof.test.ts
+++ b/functions/v2/packages/[rpn]/proof.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { onRequestGet } from "./proof.js";
+
+function makeEnv(stored: string | null) {
+  return {
+    RRF_KV: {
+      get: vi.fn(async (key: string) => {
+        if (key.startsWith("package-proof:")) return stored;
+        return null;
+      }),
+      put: vi.fn(),
+      list: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+}
+
+describe("GET /v2/packages/[rpn]/proof", () => {
+  it("returns the stored signed body when present", async () => {
+    const stored = JSON.stringify({
+      name: "robot-md-example-actuator",
+      version: "0.1.0",
+      pq_signing_pub: "BASE64",
+      pq_kid: "publisher-x",
+      ed25519_pub: "BASE64",
+      sig: { ml_dsa: "...", ed25519: "...", ed25519_pub: "..." },
+    });
+    const env = makeEnv(stored);
+    const res = await onRequestGet({
+      env,
+      params: { rpn: "RPN-000000000001" },
+    } as any);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    expect(await res.json()).toEqual(JSON.parse(stored));
+  });
+
+  it("returns 404 when no proof exists", async () => {
+    const env = makeEnv(null);
+    const res = await onRequestGet({
+      env,
+      params: { rpn: "RPN-000000000999" },
+    } as any);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 on malformed RPN", async () => {
+    const env = makeEnv(null);
+    const res = await onRequestGet({
+      env,
+      params: { rpn: "garbage" },
+    } as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/functions/v2/packages/[rpn]/proof.ts
+++ b/functions/v2/packages/[rpn]/proof.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /v2/packages/[rpn]/proof — return the original signed register body
+ * (with sig intact) so third parties can cryptographically verify the publish.
+ *
+ * The /v2/packages/[rpn] endpoint returns a "stripped" record (no sig) for
+ * catalog display; this endpoint returns the verifiable artifact. Both keys
+ * are written at register-time and stay in sync (registers are append-only at
+ * the package level — version bumps go through /versions which doesn't update
+ * the proof).
+ */
+
+import { isValidId } from "../../_lib/id.js";
+
+export interface Env { RRF_KV: KVNamespace }
+
+function err(message: string, status: number): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const onRequestGet: PagesFunction<Env, "rpn"> = async ({ env, params }) => {
+  const rpn = params.rpn as string;
+  if (!isValidId(rpn, "RPN")) return err("Malformed RPN", 400);
+  const raw = await env.RRF_KV.get(`package-proof:${rpn}`);
+  if (!raw) return err(`No proof for RPN ${rpn}`, 404);
+  return new Response(raw, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+};

--- a/functions/v2/packages/register.test.ts
+++ b/functions/v2/packages/register.test.ts
@@ -93,4 +93,15 @@ describe("POST /v2/packages/register", () => {
     await onRequestPost({ request: makePost(fx.http_body), env } as any);
     expect(env.__store["package-by-type:actuator"]).toBe("RPN-000000000001");
   });
+
+  it("writes proof KV key with original signed body (sig included)", async () => {
+    const env = makeEnv();
+    const res = await onRequestPost({ request: makePost(fx.http_body), env } as any);
+    expect(res.status).toBe(201);
+    const proofRaw = env.__store["package-proof:RPN-000000000001"];
+    expect(proofRaw).toBeTruthy();
+    const proof = JSON.parse(proofRaw);
+    expect(proof.sig).toBeDefined();
+    expect(proof.name).toBe(fx.http_body.name);
+  });
 });

--- a/functions/v2/packages/register.ts
+++ b/functions/v2/packages/register.ts
@@ -99,6 +99,7 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
   };
 
   await env.RRF_KV.put(`package:${rpn}`, JSON.stringify(record));
+  await env.RRF_KV.put(`package-proof:${rpn}`, JSON.stringify(body));
   await env.RRF_KV.put(byNameKey, rpn);
 
   const byTypeKey = `package-by-type:${package_type}`;


### PR DESCRIPTION
## Summary

Adds a GET /v2/packages/[rpn]/proof endpoint that returns the original
signed body of the package register call (with sig intact). The existing
/v2/packages/[rpn] returns a stripped record (no sig) — third parties
can't verify a publish from that endpoint alone.

Mid-flight discovery while executing Plan 4 cookbook beat 6 rewrite —
beat 7's RCAN-verify story needs the verifiable artifact this endpoint
exposes.

## What's new

- functions/v2/packages/register.ts writes package-proof:\${rpn} at
  register-time (signed body, sig included)
- functions/v2/packages/[rpn]/proof.ts (GET) reads it back

## Test plan

- [x] 1 new register-test asserts proof KV key is written
- [x] 3 new proof-endpoint tests (200, 404, 400)
- [x] Existing tests still pass
- [ ] CI green
- [ ] After merge: curl /v2/packages/[rpn]/proof returns the signed body for any newly-registered package

🤖 Generated with [Claude Code](https://claude.com/claude-code)