### PR TITLE
feat(v2/robots): reserved-floor on RRN counter + /v2/robots/_next preview

### DIFF
--- a/functions/v2/_lib/id.test.ts
+++ b/functions/v2/_lib/id.test.ts
@@ -6,7 +6,9 @@ import {
   formatId,
   isValidId,
   nextId,
+  peekNextSeq,
   prefixToCounterKey,
+  RESERVED_FLOORS,
 } from "./id.js";
 
 function makeFakeKv(seed: Record<string, string> = {}) {
@@ -67,5 +69,50 @@ describe("RPN prefix", () => {
 
   it("extractPrefix recognizes RPN", () => {
     expect(extractPrefix("RPN-000000000007")).toBe("RPN");
+  });
+});
+
+describe("RRN reserved floor", () => {
+  const FLOOR = RESERVED_FLOORS.RRN ?? 10;
+
+  it("declares a non-trivial floor for RRN", () => {
+    expect(FLOOR).toBeGreaterThanOrEqual(2);
+  });
+
+  it("nextId on a fresh counter jumps to the reserved floor", async () => {
+    const kv = makeFakeKv({});
+    expect(await nextId(kv as unknown as KVNamespace, "RRN")).toBe(formatId("RRN", FLOOR));
+  });
+
+  it("nextId on a low counter (post-reset) jumps to the reserved floor", async () => {
+    // Simulates the post-RRF-reset state where the counter has restarted at 0
+    // and would otherwise mint RRN-1, RRN-2, ... and collide with canonical
+    // robots Bob (RRN-1) / Alex (RRN-5).
+    const kv = makeFakeKv({ "counter:rrn": "0" });
+    expect(await nextId(kv as unknown as KVNamespace, "RRN")).toBe(formatId("RRN", FLOOR));
+    expect(await nextId(kv as unknown as KVNamespace, "RRN")).toBe(formatId("RRN", FLOOR + 1));
+  });
+
+  it("nextId above the floor increments normally", async () => {
+    const kv = makeFakeKv({ "counter:rrn": String(FLOOR + 5) });
+    expect(await nextId(kv as unknown as KVNamespace, "RRN")).toBe(formatId("RRN", FLOOR + 6));
+  });
+
+  it("RPN has no floor and increments from 1", async () => {
+    expect(RESERVED_FLOORS.RPN).toBeUndefined();
+    const kv = makeFakeKv({});
+    expect(await nextId(kv as unknown as KVNamespace, "RPN")).toBe(formatId("RPN", 1));
+  });
+
+  it("peekNextSeq reports the floor without incrementing", async () => {
+    const kv = makeFakeKv({});
+    expect(await peekNextSeq(kv as unknown as KVNamespace, "RRN")).toBe(FLOOR);
+    // counter:rrn must not have been written
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("peekNextSeq tracks the live counter when above the floor", async () => {
+    const kv = makeFakeKv({ "counter:rrn": String(FLOOR + 3) });
+    expect(await peekNextSeq(kv as unknown as KVNamespace, "RRN")).toBe(FLOOR + 4);
   });
 });

--- a/functions/v2/_lib/id.ts
+++ b/functions/v2/_lib/id.ts
@@ -20,9 +20,38 @@ export function prefixToCounterKey(prefix: EntityPrefix): string {
   return `counter:${prefix.toLowerCase()}`;
 }
 
+/**
+ * Reserved-floor per prefix: auto-mints never produce a sequence below this
+ * value. Slots below the floor are reserved for canonical/curated entities
+ * (e.g. RRN-000000000001 = Bob, RRN-000000000005 = Alex) so a counter reset
+ * — which restarts the sequence at 1 — does not silently collide with
+ * documented well-known IDs. Operators wanting one of the reserved slots
+ * must contact RRF for manual assignment.
+ *
+ * Set the floor with a generous margin so future canonical robots can be
+ * added without bumping it again.
+ */
+export const RESERVED_FLOORS: Partial<Record<EntityPrefix, number>> = {
+  RRN: 10,
+};
+
 /** Format a sequence number as a zero-padded 12-digit ID. */
 export function formatId(prefix: EntityPrefix, seq: number): string {
   return `${prefix}-${String(seq).padStart(12, "0")}`;
+}
+
+/**
+ * Return the sequence number nextId() will allocate on the next call,
+ * WITHOUT incrementing the counter. Used by the /v2/robots/_next preview
+ * endpoint so operators can see which RRN they'll receive before they sign
+ * a registration body.
+ */
+export async function peekNextSeq(kv: KVNamespace, prefix: EntityPrefix): Promise<number> {
+  const key = prefixToCounterKey(prefix);
+  const current = await kv.get(key, "text");
+  const raw = current ? parseInt(current, 10) + 1 : 1;
+  const floor = RESERVED_FLOORS[prefix] ?? 0;
+  return raw < floor ? floor : raw;
 }
 
 /**
@@ -30,11 +59,17 @@ export function formatId(prefix: EntityPrefix, seq: number): string {
  * new sequential ID.  Uses optimistic locking: reads the current value, adds 1,
  * writes back with the old value as a guard (KV does not support CAS natively,
  * so we use a single-writer assumption acceptable for low-traffic RRF).
+ *
+ * Respects RESERVED_FLOORS: if the computed sequence falls inside a prefix's
+ * reserved range, jumps the counter forward to the floor and returns the
+ * floor value instead.
  */
 export async function nextId(kv: KVNamespace, prefix: EntityPrefix): Promise<string> {
   const key = prefixToCounterKey(prefix);
   const current = await kv.get(key, "text");
-  const seq = current ? parseInt(current, 10) + 1 : 1;
+  let seq = current ? parseInt(current, 10) + 1 : 1;
+  const floor = RESERVED_FLOORS[prefix] ?? 0;
+  if (seq < floor) seq = floor;
   await kv.put(key, String(seq));
   return formatId(prefix, seq);
 }

--- a/functions/v2/robots/_next.test.ts
+++ b/functions/v2/robots/_next.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { onRequestGet } from "./_next.js";
+import { RESERVED_FLOORS } from "../_lib/id.js";
+
+function makeFakeKv(seed: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...seed };
+  return {
+    get: vi.fn(async (k: string, _opts?: unknown) => store[k] ?? null),
+    put: vi.fn(async (k: string, v: string) => {
+      store[k] = v;
+    }),
+    list: vi.fn(),
+    delete: vi.fn(async (k: string) => {
+      delete store[k];
+    }),
+  };
+}
+
+function ctx(kv: ReturnType<typeof makeFakeKv>) {
+  return {
+    env: { RRF_KV: kv as unknown as KVNamespace },
+  } as unknown as Parameters<typeof onRequestGet>[0];
+}
+
+describe("GET /v2/robots/_next", () => {
+  const FLOOR = RESERVED_FLOORS.RRN ?? 10;
+
+  it("returns the reserved floor on a fresh counter", async () => {
+    const kv = makeFakeKv({});
+    const res = await onRequestGet(ctx(kv));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.next_rrn).toBe(`RRN-${String(FLOOR).padStart(12, "0")}`);
+    expect(body.reserved_floor).toBe(FLOOR);
+  });
+
+  it("returns the live next-seq when counter is above the floor", async () => {
+    const kv = makeFakeKv({ "counter:rrn": String(FLOOR + 7) });
+    const res = await onRequestGet(ctx(kv));
+    const body = await res.json();
+    expect(body.next_rrn).toBe(`RRN-${String(FLOOR + 8).padStart(12, "0")}`);
+  });
+
+  it("never advances the counter (read-only)", async () => {
+    const kv = makeFakeKv({ "counter:rrn": "5" });
+    await onRequestGet(ctx(kv));
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("sets Cache-Control: no-store so previews are never stale", async () => {
+    const kv = makeFakeKv({});
+    const res = await onRequestGet(ctx(kv));
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+});

--- a/functions/v2/robots/_next.ts
+++ b/functions/v2/robots/_next.ts
@@ -1,0 +1,40 @@
+/**
+ * GET /v2/robots/_next
+ *
+ * Returns the RRN that the next call to POST /v2/robots/register will
+ * allocate, plus the reserved-floor so clients understand why. Read-only;
+ * does not advance the counter.
+ *
+ * Body:
+ *   {
+ *     "next_rrn": "RRN-000000000010",
+ *     "reserved_floor": 10,
+ *     "note": "RRN-000000000001..RRN-000000000009 reserved for canonical robots"
+ *   }
+ */
+
+import { formatId, peekNextSeq, RESERVED_FLOORS } from "../_lib/id.js";
+
+export interface Env {
+  RRF_KV: KVNamespace;
+}
+
+export const onRequestGet: PagesFunction<Env> = async ({ env }) => {
+  const seq = await peekNextSeq(env.RRF_KV, "RRN");
+  const reserved_floor = RESERVED_FLOORS.RRN ?? 0;
+  const body = {
+    next_rrn: formatId("RRN", seq),
+    reserved_floor,
+    note: reserved_floor > 0
+      ? `RRN-${String(1).padStart(12, "0")}..RRN-${String(reserved_floor - 1).padStart(12, "0")} ` +
+        `reserved for canonical robots; auto-mints start at RRN-${String(reserved_floor).padStart(12, "0")}`
+      : "no reserved range",
+  };
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+};


### PR DESCRIPTION
## Summary

Closes Spec A baseline friction #2 (RRN collision on \`--register\`). After the 2026-05-09 RRF reset, the RRN counter restarted at 0 so every new auto-mint clashed with documented canonical robots (Bob = RRN-1, Alex = RRN-5). The Spec A subagent's \`robot-md init --register\` minted RRN-000000000002 — a guardrail-protected slot.

Two complementary changes:

- **\`RESERVED_FLOORS\` map in \`_lib/id.ts\`** — RRN floor = 10. \`nextId()\` jumps the counter past the floor when below it, so post-reset mints start at RRN-000000000010. Other prefixes (RPN/RCN/RMN/RHN) unchanged.
- **\`GET /v2/robots/_next\`** — returns the RRN that the next mint will allocate plus the reserved-floor metadata. Read-only (does not advance the counter, \`Cache-Control: no-store\`) so CLIs can preflight a registration request without consuming a slot.

Operators can no longer accidentally squat on a canonical slot, and they can see which RRN they'll receive before signing the body. The robot-md CLI side (preflight call during \`--register\`) follows in a separate PR.

## Test plan

- [x] \`npx vitest run functions/v2/_lib/id.test.ts\` — 15 pass (+7 new)
- [x] \`npx vitest run functions/v2/robots/_next.test.ts\` — 4 pass (new)
- [x] Full vitest suite — 392/392 pass
- [x] \`npm run build\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)