### PR TITLE
fix(v2/authorities): write the kid mapping on register so /v2/keys resolves (completes #84)

### DIFF
--- a/functions/v2/authorities/register.ts
+++ b/functions/v2/authorities/register.ts
@@ -150,5 +150,27 @@ export const onRequestPost: PagesFunction<Env> = async ({ env, request }) => {
   });
   await env.RRF_KV.put("counter:ran", String(next));
 
-  return json({ ran, status: "active", registered_at: record.registered_at }, 201);
+  // Wire `/v2/keys/<kid>` resolution. The resolver (functions/v2/keys/[kid].ts)
+  // scans `kid:<kid>:*` mappings and 404s without one — so registering an
+  // authority but never writing this mapping leaves a freshly-minted operator
+  // unverifiable: a robot-md-gateway resolving the kid gets 404 and denies the
+  // envelope/manifest signature. Index by `pq_kid` (deterministic, and already
+  // enforced unique in this namespace above) rather than a caller-supplied
+  // string, so a public registration can't squat an existing kid.
+  const kidMapping = {
+    ran,
+    valid_from: record.registered_at,
+    registered_at: record.registered_at,
+    registered_by: ran,
+  };
+  await env.RRF_KV.put(
+    `kid:${record.pq_kid}:${record.registered_at}`,
+    JSON.stringify(kidMapping),
+    { expirationTtl: 365 * 24 * 3600 * 10 },
+  );
+
+  return json(
+    { ran, kid: record.pq_kid, status: "active", registered_at: record.registered_at },
+    201,
+  );
 };

--- a/tests/api/v2/authorities.test.ts
+++ b/tests/api/v2/authorities.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi } from "vitest";
 import { onRequestPost } from "../../../functions/v2/authorities/register.js";
 import { onRequestGet as onGetSingle, onRequestDelete } from "../../../functions/v2/authorities/[ran]/index.js";
 import { onRequestGet as onGetList } from "../../../functions/v2/authorities/index.js";
+import { onRequest as onKeyResolve } from "../../../functions/v2/keys/[kid].js";
 import { signBody } from "rcan-ts";
 import { makeTestKeypair } from "../../../functions/v2/_lib/test-helpers.js";
 
@@ -86,6 +87,36 @@ describe("/v2/authorities — RAN namespace", () => {
     expect(out.ran).toMatch(/^RAN-\d{12}$/);
     expect(out.status).toBe("active");
     expect(out.registered_at).toBeTruthy();
+  });
+
+  it("registration wires /v2/keys/<pq_kid> so a gateway can resolve the new operator", async () => {
+    const env = makeEnv();
+    const body = await buildSignedRegistration({
+      organization: "OpenCastor",
+      display_name: "Operator envelope signer",
+      purpose: "operator-envelope",
+    });
+    const postRes = await onRequestPost({
+      request: makeReq("POST", "https://x/v2/authorities/register", body),
+      env,
+    } as any);
+    expect(postRes.status).toBe(201);
+    const post = (await postRes.json()) as any;
+    // The response advertises the kid to sign envelopes/manifests with.
+    expect(post.kid).toBe((body as any).pq_kid);
+
+    // A robot-md-gateway (RRFResolverFromEnv) resolves that kid here before it
+    // will verify any signature. Without the kid-mapping write this 404s.
+    const keysRes = await onKeyResolve({
+      params: { kid: post.kid },
+      env,
+      request: makeReq("GET", `https://x/v2/keys/${post.kid}`),
+    } as any);
+    expect(keysRes.status).toBe(200);
+    const resolved = (await keysRes.json()) as any;
+    expect(resolved.kid).toBe(post.kid);
+    expect(resolved.alg).toBe("Ed25519");
+    expect(resolved.public_key_pem).toMatch(/BEGIN PUBLIC KEY/);
   });
 
   it("GET /v2/authorities/<ran> returns the persisted record (200)", async () => {


### PR DESCRIPTION
## Problem

`POST /v2/authorities/register` persisted only `authority:<RAN>` (+ `counter:ran`). But `GET /v2/keys/<kid>` resolves by scanning `kid:<kid>:*` mappings and **404s when none exists**. So a freshly-registered operator authority was **unresolvable** — a `robot-md-gateway`'s `RRFResolverFromEnv` gets 404 and denies the signature — even though the `operator-envelope` purpose exists precisely for envelope/manifest signers.

This silently broke an already-shipped client-side fix: `robot-md register` calls `_register_envelope_authority` to POST the robot's key here "so the gateway's `/v2/keys/<pq_kid>` resolver can find an Ed25519 PEM for it" (closes #84). That POST succeeded but the resolver still 404'd, because **the server never wrote the `kid:` mapping the resolver reads**. Only the admin `scripts/register-operator-kid.ts` (manual `wrangler kv bulk put`) ever populated it.

## Fix

On successful registration, also write:

```
kid:<pq_kid>:<registered_at>  ->  { ran, valid_from, registered_at, registered_by }
```

- Keyed by **`pq_kid`** (deterministic from the key, and already enforced unique in the RAN namespace) rather than a caller-supplied string — so a public registration can't squat an existing kid (the same key-confusion concern the existing pq_kid-uniqueness check guards).
- The response now returns `kid` so callers know what to advertise in envelopes/manifests.

## Test

Adds a **register → `GET /v2/keys/<kid>` chain test**: register an `operator-envelope` authority, then resolve the returned `kid` and assert a 200 with its Ed25519 `public_key_pem`. (Previously this would 404.) Existing authorities/keys/kid-resolve/register-operator-kid tests still pass (28/28 across those files).

## Effect

Completes #84 end-to-end: after a fresh `robot-md register`, the robot's `pq_kid` resolves at `/v2/keys`, so `robot-md-gateway` can verify its manifest-provenance and envelope signatures — signed control works without the admin bulk-put step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)