### PR TITLE
U1b: RRF attestation registration (hybrid mint + /v2/keys round-trip + runbook)

### DIFF
--- a/docs/runbooks/u1b-attestation-registration.md
+++ b/docs/runbooks/u1b-attestation-registration.md
@@ -1,0 +1,83 @@
+# U1b — RRF Attestation Registration Runbook
+
+Mint a hybrid attestation keypair, register its `kid` in RRF bound to GitHub org
+`OpenCastor`, provision **only** the Ed25519 private key to the gateway, and archive
+the ML-DSA key offline. PQ is **mandatory** in RRF: hybrid is required both to register
+(`register.ts:46-106`) and to serve (`keys/[kid].ts:136-141`). Do **not** relax this.
+
+Prereqs:
+- `~/rcan-py/.venv/bin/python` with rcan 3.4.0 (`[pq]` + `[crypto]`). Verify:
+  `~/rcan-py/.venv/bin/python -c "import rcan, dilithium_py, cryptography; print(rcan.__version__)"` → `3.4.0`.
+- `wrangler` authenticated for the RRF account (KV namespace binding `RRF_KV`, id in `wrangler.toml`).
+- An RRF RAN for this attestation authority (the `--ran` below). NOTE: `register-operator-kid.ts`
+  takes an explicit RAN and does NOT use `counter:ran`; pick a RAN that does not collide with any
+  existing `authority:RAN-*` and is outside the range `POST /v2/authorities/register` will auto-assign.
+  Confirm it is free:  `wrangler kv key get "authority:RAN-000000000021" --binding RRF_KV --remote`  → expect "key not found".
+
+Choose values (used throughout):
+    KID=bob-gw-attest-2026
+    RAN=RAN-000000000021
+    REGISTERED_BY=RAN-000000000018
+    VALID_FROM=2026-06-06T00:00:00.000Z
+    MINT_DIR=~/.opencastor-ops-keys/attestation-2026-06-06
+
+## 1. Mint the keypair + registration body
+    ~/rcan-py/.venv/bin/python ~/RobotRegistryFoundation/scripts/mint-attestation-kid.py \
+      --organization OpenCastor \
+      --display-name "Bob gateway attestation signer" \
+      --out-dir "$MINT_DIR"
+Output prints the `pq_kid` and `signing_pub`; `$MINT_DIR` now holds
+`attestation-ed25519-private.pem`, `attestation-mldsa65-private.pem`, `mint-manifest.json`.
+
+## 2. Generate the `wrangler kv bulk put` record
+Read the minted values straight from the manifest (no hand-copying):
+    SIGNING_PUB=$(~/rcan-py/.venv/bin/python -c "import json,sys;print(json.load(open('$MINT_DIR/mint-manifest.json'))['signing_pub_b64'])")
+    PQ_PUB=$(~/rcan-py/.venv/bin/python -c "import json,sys;print(json.load(open('$MINT_DIR/mint-manifest.json'))['pq_signing_pub_b64'])")
+    PQ_KID=$(~/rcan-py/.venv/bin/python -c "import json,sys;print(json.load(open('$MINT_DIR/mint-manifest.json'))['pq_kid'])")
+
+    cd ~/RobotRegistryFoundation
+    npx tsx scripts/register-operator-kid.ts \
+      --kid "$KID" \
+      --ran "$RAN" \
+      --signing-pub-b64 "$SIGNING_PUB" \
+      --pq-signing-pub-b64 "$PQ_PUB" \
+      --pq-kid "$PQ_KID" \
+      --organization OpenCastor \
+      --display-name "Bob gateway attestation signer" \
+      --purpose attestation \
+      --registered-by "$REGISTERED_BY" \
+      --valid-from "$VALID_FROM" \
+      --out /tmp/u1b-attestation-kv.json
+This writes a 2-element JSON array: `kid:<KID>:<ts>` + `authority:<RAN>`.
+
+## 3. Push to KV (scope item 4)
+    cd ~/RobotRegistryFoundation
+    wrangler kv bulk put /tmp/u1b-attestation-kv.json --binding RRF_KV --remote
+Expect: `Success! ... 2 ... key value pairs.`
+
+## 4. Verify the served key (scope item: GET 200 with public_key_pem + status:active)
+    curl -s https://rcan.dev/v2/keys/$KID | python3 -m json.tool
+Expect HTTP 200 and a body with:
+  - `"status": "active"`
+  - `"alg": "Ed25519"` and a `"public_key_pem"` beginning `-----BEGIN PUBLIC KEY-----`
+  - `"pq_alg": "ML-DSA-65"`, `"pq_public_key_b64"` (1952-byte decode), `"pq_kid"` == `$PQ_KID`, `"ran"` == `$RAN`
+A 404 → the `kid:*` mapping did not land (re-check step 3). A 502 → byte-length/integrity gate
+(`keys/[kid].ts:136-141`); re-mint, the pub bytes are wrong.
+
+## 5. Provision the gateway (Ed25519 only) — scope item 5 / U1a files
+Provision out-of-band to the gateway host (never commit these):
+    ROBOT_MD_ATTESTATION_KEY_FILE = $MINT_DIR/attestation-ed25519-private.pem
+    ROBOT_MD_ATTESTATION_KID      = bob-gw-attest-2026
+    ROBOT_MD_ATTESTATION_RAN      = RAN-000000000021
+The gateway-side loader that reads these env vars is U1a's scope — out of scope here.
+The **public** kid/RAN may live in `OpenCastor/bob-spec-b-pick-place` non-secret config; the
+PEM must NOT (spec §11.1: keys stay in `~/.opencastor-ops-keys`).
+
+## 6. Archive the ML-DSA private key OFFLINE — scope item 5
+`attestation-mldsa65-private.pem` is needed only to re-register/rotate. Move it to offline cold
+storage (the operator key vault); it MUST NOT reach the robot/gateway. Rotation = re-mint +
+re-register (new RAN) + re-provision the new Ed25519 PEM.
+
+## Rollback
+Revoke the authority: `wrangler kv key put "authority:$RAN" "<record with status:revoked, revoked_at>" --binding RRF_KV --remote`.
+`GET /v2/keys/$KID` then returns 410 (`keys/[kid].ts:121-126`) → S3 maps to `revoked`.

--- a/functions/v2/keys/[kid].test.ts
+++ b/functions/v2/keys/[kid].test.ts
@@ -193,3 +193,138 @@ describe("GET /v2/keys/<kid>", () => {
     expect(body.pq_kid).toBe("cafef00d");
   });
 });
+
+// ── U1b: provisioned-Ed25519 round-trip against the served public_key_pem ──────
+// Mirrors proxy-worker src/crypto/canonical-json.ts (canonicalBytes) and
+// src/crypto/rcan-verify.ts (verifyEnvelope) so this proves S3 can verify.
+
+function u1bCanonicalBytes(obj: Record<string, unknown>, exclude?: string): Uint8Array {
+  const normalize = (v: unknown): unknown => {
+    if (Array.isArray(v)) return v.map(normalize);
+    if (v !== null && typeof v === "object") {
+      const out: Record<string, unknown> = {};
+      for (const k of Object.keys(v as Record<string, unknown>).sort())
+        out[k] = normalize((v as Record<string, unknown>)[k]);
+      return out;
+    }
+    return v;
+  };
+  const src = exclude
+    ? Object.fromEntries(Object.entries(obj).filter(([k]) => k !== exclude))
+    : obj;
+  return new TextEncoder().encode(JSON.stringify(normalize(src)));
+}
+
+function u1bRawFromPem(pem: string): Uint8Array {
+  const b64s = pem.replace(/-----[^-]+-----/g, "").replace(/\s+/g, "");
+  const der = Uint8Array.from(atob(b64s), (c) => c.charCodeAt(0));
+  return der.slice(der.length - 32);
+}
+
+describe("U1b attestation round-trip — provisioned Ed25519 verifies against served PEM", () => {
+  it("GET 200 returns public_key_pem + status:active, and an outcome signed by the provisioned seed verifies against it", async () => {
+    const { env, store } = makeEnv();
+
+    // Seed KV with a minted attestation authority. We control the Ed25519 priv
+    // (the "provisioned" key) so we can sign an outcome with it below.
+    const ed25519Priv = crypto.getRandomValues(new Uint8Array(32));
+    const ed25519Pub = ed25519.getPublicKey(ed25519Priv);
+    const pqPub = crypto.getRandomValues(new Uint8Array(1952));
+    const kid = "bob-gw-attest-2026";
+    const ran = "RAN-000000000021";
+    store[`kid:${kid}:2026-06-06T00:00:00.000Z`] = JSON.stringify({
+      ran,
+      valid_from: "2026-06-06T00:00:00.000Z",
+      registered_at: "2026-06-06T00:00:00.000Z",
+      registered_by: "RAN-000000000018",
+    });
+    store[`authority:${ran}`] = JSON.stringify({
+      ran,
+      organization: "OpenCastor",
+      display_name: "Bob gateway attestation signer",
+      purpose: "attestation",
+      signing_pub: b64(ed25519Pub),
+      pq_signing_pub: b64(pqPub),
+      pq_kid: "deadbeef",
+      signing_alg: ["Ed25519", "ML-DSA-65"],
+      registered_at: "2026-06-06T00:00:00.000Z",
+      status: "active",
+    });
+
+    // 1. S3 resolves the key: GET /v2/keys/<kid> → 200 with public_key_pem + active.
+    const res = await onRequest(makeContext(env, { kid }));
+    expect(res.status).toBe(200);
+    const keyDoc = (await res.json()) as Record<string, unknown>;
+    expect(keyDoc.status).toBe("active");
+    expect(keyDoc.public_key_pem).toMatch(
+      /^-----BEGIN PUBLIC KEY-----\n[A-Za-z0-9+/=\n]+-----END PUBLIC KEY-----\n$/,
+    );
+
+    // 2. Build a flat S3 outcome envelope (spec §3.4) and sign it with the
+    //    provisioned Ed25519 seed using the canonical-JSON preimage S3 uses.
+    const outcome: Record<string, unknown> = {
+      corr_id: "msg-u1b-001",
+      rrn: "RRN-000000000011",
+      status: "ok",
+      started_at: "2026-06-06T00:00:00Z",
+      ended_at: "2026-06-06T00:00:00.12Z",
+      duration_ms: 120,
+    };
+    const sig = ed25519.sign(u1bCanonicalBytes(outcome, "envelope_signature"), ed25519Priv);
+    outcome.envelope_signature = {
+      kid,
+      alg: "Ed25519",
+      sig: btoa(String.fromCharCode(...sig)),
+    };
+
+    // 3. S3-side verify: decode public_key_pem from the GET response and verify
+    //    the detached envelope_signature over the canonical preimage.
+    const sigBytes = Uint8Array.from(
+      atob((outcome.envelope_signature as { sig: string }).sig),
+      (c) => c.charCodeAt(0),
+    );
+    const verified = ed25519.verify(
+      sigBytes,
+      u1bCanonicalBytes(outcome, "envelope_signature"),
+      u1bRawFromPem(keyDoc.public_key_pem as string),
+    );
+    expect(verified).toBe(true);
+  });
+
+  it("rejects a tampered outcome (mutating a signed field breaks verification)", async () => {
+    const { env, store } = makeEnv();
+    const ed25519Priv = crypto.getRandomValues(new Uint8Array(32));
+    const ed25519Pub = ed25519.getPublicKey(ed25519Priv);
+    const pqPub = crypto.getRandomValues(new Uint8Array(1952));
+    const kid = "bob-gw-attest-2026";
+    const ran = "RAN-000000000021";
+    store[`kid:${kid}:2026-06-06T00:00:00.000Z`] = JSON.stringify({
+      ran, valid_from: "2026-06-06T00:00:00.000Z",
+      registered_at: "2026-06-06T00:00:00.000Z", registered_by: "RAN-000000000018",
+    });
+    store[`authority:${ran}`] = JSON.stringify({
+      ran, organization: "OpenCastor", display_name: "Bob gateway attestation signer",
+      purpose: "attestation", signing_pub: b64(ed25519Pub), pq_signing_pub: b64(pqPub),
+      pq_kid: "deadbeef", signing_alg: ["Ed25519", "ML-DSA-65"],
+      registered_at: "2026-06-06T00:00:00.000Z", status: "active",
+    });
+    const res = await onRequest(makeContext(env, { kid }));
+    const keyDoc = (await res.json()) as Record<string, unknown>;
+
+    const outcome: Record<string, unknown> = {
+      corr_id: "msg-u1b-002", rrn: "RRN-000000000011", status: "ok",
+      started_at: "2026-06-06T00:00:00Z", ended_at: "2026-06-06T00:00:00.12Z",
+    };
+    const sig = ed25519.sign(u1bCanonicalBytes(outcome, "envelope_signature"), ed25519Priv);
+    outcome.envelope_signature = { kid, alg: "Ed25519", sig: btoa(String.fromCharCode(...sig)) };
+
+    // Tamper a SIGNED field after signing.
+    outcome.status = "denied";
+    const sigBytes = Uint8Array.from(
+      atob((outcome.envelope_signature as { sig: string }).sig), (c) => c.charCodeAt(0));
+    const verified = ed25519.verify(
+      sigBytes, u1bCanonicalBytes(outcome, "envelope_signature"),
+      u1bRawFromPem(keyDoc.public_key_pem as string));
+    expect(verified).toBe(false);
+  });
+});

--- a/scripts/mint-attestation-kid.py
+++ b/scripts/mint-attestation-kid.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import base64
 import json
+import os
 from pathlib import Path
 
 from cryptography.hazmat.primitives import serialization
@@ -38,6 +39,8 @@ def main() -> None:
 
     out = Path(args.out_dir)
     out.mkdir(parents=True, exist_ok=True)
+    # Private signing keys land here; keep the dir owner-only too (best-effort).
+    os.chmod(out, 0o700)
 
     # 1. Ed25519: PKCS8 PEM (gateway), raw 32-byte seed (sign_body), raw 32-byte pub (registered).
     ed = Ed25519PrivateKey.generate()
@@ -76,13 +79,18 @@ def main() -> None:
     assert body["sig"]["ed25519_pub"] == meta["signing_pub"]
 
     # 4. Write the gateway private-key PEM (provision) and ML-DSA archive (offline).
-    (out / "attestation-ed25519-private.pem").write_bytes(ed_pem)
+    #    Private signing keys must never be group/other readable — chmod 0600 after write.
+    ed_priv_path = out / "attestation-ed25519-private.pem"
+    ed_priv_path.write_bytes(ed_pem)
+    os.chmod(ed_priv_path, 0o600)
     mldsa_archive = (
         "-----BEGIN ML-DSA-65 PRIVATE KEY-----\n"
         + b64(kp._secret_key)
         + "\n-----END ML-DSA-65 PRIVATE KEY-----\n"
     )
-    (out / "attestation-mldsa65-private.pem").write_text(mldsa_archive)
+    mldsa_priv_path = out / "attestation-mldsa65-private.pem"
+    mldsa_priv_path.write_text(mldsa_archive)
+    os.chmod(mldsa_priv_path, 0o600)
 
     # 5. The manifest: everything the registration step (Task 2 / runbook) needs.
     manifest = {

--- a/scripts/mint-attestation-kid.py
+++ b/scripts/mint-attestation-kid.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Mint a hybrid Ed25519 + ML-DSA-65 attestation keypair for U1b.
+
+Emits into --out-dir:
+  attestation-ed25519-private.pem   PKCS8 PEM — provision to the gateway (U1a)
+  attestation-mldsa65-private.pem   ML-DSA-65 raw secret (base64 PEM-like) — ARCHIVE OFFLINE
+  mint-manifest.json                every value the registration step needs
+
+Run with the rcan venv:  ~/rcan-py/.venv/bin/python scripts/mint-attestation-kid.py ...
+
+The registration_body in mint-manifest.json is produced by rcan.hybrid.sign_body and is
+byte-compatible with RobotRegistryFoundation/functions/v2/authorities/register.ts verifyBody.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from rcan import generate_ml_dsa_keypair, sign_body
+
+
+def b64(raw: bytes) -> str:
+    return base64.b64encode(raw).decode("ascii")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Mint a hybrid attestation keypair (U1b).")
+    ap.add_argument("--organization", required=True, help="RRF authority organization (free-form), e.g. OpenCastor")
+    ap.add_argument("--display-name", required=True, help="human label for the authority record")
+    ap.add_argument("--purpose", default="attestation", help="AuthorityPurpose (default: attestation)")
+    ap.add_argument("--out-dir", required=True, help="directory to write the three artifacts into")
+    args = ap.parse_args()
+
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # 1. Ed25519: PKCS8 PEM (gateway), raw 32-byte seed (sign_body), raw 32-byte pub (registered).
+    ed = Ed25519PrivateKey.generate()
+    ed_pem = ed.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    ed_seed = ed.private_bytes(
+        serialization.Encoding.Raw,
+        serialization.PrivateFormat.Raw,
+        serialization.NoEncryption(),
+    )
+    ed_pub = ed.public_key().public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    )
+    assert len(ed_seed) == 32 and len(ed_pub) == 32
+
+    # 2. ML-DSA-65 keypair (pub = 1952 bytes; key_id = sha256(pub)[:8]).
+    kp = generate_ml_dsa_keypair()
+    assert len(kp.public_key_bytes) == 1952
+    assert kp._secret_key is not None
+
+    # 3. Hybrid registration body. sign_body adds pq_signing_pub, pq_kid, and
+    #    sig.{ml_dsa,ed25519,ed25519_pub}; pq_kid == sha256(pq_pub)[:8] == kp.key_id.
+    meta = {
+        "organization": args.organization,
+        "display_name": args.display_name,
+        "purpose": args.purpose,
+        "signing_pub": b64(ed_pub),
+        "signing_alg": ["Ed25519", "ML-DSA-65"],
+    }
+    body = sign_body(kp, meta, ed25519_secret=ed_seed, ed25519_public=ed_pub)
+    assert body["pq_kid"] == kp.key_id
+    assert body["sig"]["ed25519_pub"] == meta["signing_pub"]
+
+    # 4. Write the gateway private-key PEM (provision) and ML-DSA archive (offline).
+    (out / "attestation-ed25519-private.pem").write_bytes(ed_pem)
+    mldsa_archive = (
+        "-----BEGIN ML-DSA-65 PRIVATE KEY-----\n"
+        + b64(kp._secret_key)
+        + "\n-----END ML-DSA-65 PRIVATE KEY-----\n"
+    )
+    (out / "attestation-mldsa65-private.pem").write_text(mldsa_archive)
+
+    # 5. The manifest: everything the registration step (Task 2 / runbook) needs.
+    manifest = {
+        "organization": args.organization,
+        "display_name": args.display_name,
+        "purpose": args.purpose,
+        "signing_alg": ["Ed25519", "ML-DSA-65"],
+        "signing_pub_b64": b64(ed_pub),
+        "pq_signing_pub_b64": body["pq_signing_pub"],
+        "pq_kid": body["pq_kid"],
+        "ed25519_private_pem_file": "attestation-ed25519-private.pem",
+        "mldsa_private_pem_file": "attestation-mldsa65-private.pem",
+        "registration_body": body,
+    }
+    (out / "mint-manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+    print(f"minted attestation keypair → {out}")
+    print(f"  organization : {args.organization}")
+    print(f"  pq_kid       : {body['pq_kid']}")
+    print(f"  signing_pub  : {b64(ed_pub)}")
+    print(f"  pq_signing_pub bytes: {len(base64.b64decode(body['pq_signing_pub']))}")
+    print("  PROVISION attestation-ed25519-private.pem to the gateway (U1a).")
+    print("  ARCHIVE   attestation-mldsa65-private.pem OFFLINE (never reaches the robot).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mint-attestation-kid.test.ts
+++ b/tests/mint-attestation-kid.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { onRequestPost } from "../functions/v2/authorities/register.js";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolve } from "node:path";
+
+const PY = "/home/craigm26/rcan-py/.venv/bin/python";
+const SCRIPT = resolve(__dirname, "..", "scripts", "mint-attestation-kid.py");
+
+// KV mock mirrors functions/v2/keys/[kid].test.ts and tests/api/v2/authorities.test.ts.
+function makeEnv() {
+  const store: Record<string, string> = {};
+  return {
+    RRF_KV: {
+      get: vi.fn(async (k: string) => store[k] ?? null),
+      put: vi.fn(async (k: string, v: string) => { store[k] = v; }),
+      list: vi.fn(async (o: { prefix?: string }) => ({
+        keys: Object.keys(store).filter((k) => k.startsWith(o?.prefix ?? "")).map((name) => ({ name })),
+        list_complete: true,
+      })),
+      delete: vi.fn(),
+    } as unknown as KVNamespace,
+  };
+}
+
+function runMint(outDir: string): Record<string, unknown> {
+  execFileSync(PY, [SCRIPT, "--organization", "OpenCastor", "--display-name",
+    "Bob gateway attestation signer", "--out-dir", outDir], { encoding: "utf-8" });
+  return JSON.parse(readFileSync(join(outDir, "mint-manifest.json"), "utf-8"));
+}
+
+describe("mint-attestation-kid.py", () => {
+  it("writes the gateway PEM, ML-DSA archive, and a mint-manifest", () => {
+    const dir = mkdtempSync(join(tmpdir(), "mint-"));
+    const manifest = runMint(dir);
+    expect(existsSync(join(dir, "attestation-ed25519-private.pem"))).toBe(true);
+    expect(existsSync(join(dir, "attestation-mldsa65-private.pem"))).toBe(true);
+    expect(manifest.organization).toBe("OpenCastor");
+    expect(manifest.signing_alg).toEqual(["Ed25519", "ML-DSA-65"]);
+    expect(typeof manifest.pq_kid).toBe("string");
+    expect((manifest.pq_kid as string)).toMatch(/^[0-9a-f]{8}$/);
+    // raw pub decodes to 32, pq pub to 1952 — the byte lengths RRF enforces.
+    expect(Buffer.from(manifest.signing_pub_b64 as string, "base64").length).toBe(32);
+    expect(Buffer.from(manifest.pq_signing_pub_b64 as string, "base64").length).toBe(1952);
+  });
+
+  it("emits a hybrid body that passes the real register.ts verifyBody (PoP + Python↔TS interop, 201)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "mint-"));
+    const manifest = runMint(dir);
+    const body = manifest.registration_body as Record<string, unknown>;
+    // Shape required by register.ts (verified §2.2): sig.{ml_dsa,ed25519,ed25519_pub},
+    // signing_alg exact tuple, sig.ed25519_pub === signing_pub.
+    const sig = body.sig as Record<string, string>;
+    expect(sig.ml_dsa && sig.ed25519 && sig.ed25519_pub).toBeTruthy();
+    expect(sig.ed25519_pub).toBe(body.signing_pub);
+    expect(body.signing_alg).toEqual(["Ed25519", "ML-DSA-65"]);
+    expect(body.purpose).toBe("attestation");
+    const res = await onRequestPost({
+      request: new Request("https://x/v2/authorities/register", {
+        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+      }),
+      env: makeEnv(),
+    } as any);
+    expect(res.status).toBe(201);
+  });
+});

--- a/tests/u1b-runbook-kv-record.test.ts
+++ b/tests/u1b-runbook-kv-record.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const PY = "/home/craigm26/rcan-py/.venv/bin/python";
+const MINT = resolve(__dirname, "..", "scripts", "mint-attestation-kid.py");
+const REGISTER = resolve(__dirname, "..", "scripts", "register-operator-kid.ts");
+
+// Reproduces the runbook's register step: mint → feed manifest values into
+// register-operator-kid.ts → assert the wrangler-kv-bulk-put pair is well-formed.
+describe("U1b runbook — register-operator-kid.ts emits the attestation KV pair", () => {
+  it("produces kid:<kid>:<ts> + authority:<ran> with purpose=attestation, org=OpenCastor", () => {
+    const dir = mkdtempSync(join(tmpdir(), "u1b-"));
+    execFileSync(PY, [MINT, "--organization", "OpenCastor", "--display-name",
+      "Bob gateway attestation signer", "--out-dir", dir], { encoding: "utf-8" });
+    const m = JSON.parse(readFileSync(join(dir, "mint-manifest.json"), "utf-8"));
+
+    const kid = "bob-gw-attest-2026";
+    const ran = "RAN-000000000021";
+    const stdout = execFileSync("npx", ["tsx", REGISTER,
+      "--kid", kid,
+      "--ran", ran,
+      "--signing-pub-b64", m.signing_pub_b64,
+      "--pq-signing-pub-b64", m.pq_signing_pub_b64,
+      "--pq-kid", m.pq_kid,
+      "--organization", "OpenCastor",
+      "--display-name", "Bob gateway attestation signer",
+      "--purpose", "attestation",
+      "--registered-by", "RAN-000000000018",
+      "--valid-from", "2026-06-06T00:00:00.000Z",
+    ], { encoding: "utf-8" });
+
+    const bulk = JSON.parse(stdout) as Array<{ key: string; value: string }>;
+    expect(bulk).toHaveLength(2);
+    const kidRec = bulk.find((r) => r.key.startsWith(`kid:${kid}:`));
+    const authRec = bulk.find((r) => r.key === `authority:${ran}`);
+    expect(kidRec).toBeDefined();
+    expect(authRec).toBeDefined();
+    const auth = JSON.parse(authRec!.value);
+    expect(auth.ran).toBe(ran);
+    expect(auth.organization).toBe("OpenCastor");
+    expect(auth.purpose).toBe("attestation");
+    expect(auth.signing_alg).toEqual(["Ed25519", "ML-DSA-65"]);
+    expect(auth.pq_kid).toBe(m.pq_kid);
+    expect(Buffer.from(auth.signing_pub, "base64").length).toBe(32);
+    expect(Buffer.from(auth.pq_signing_pub, "base64").length).toBe(1952);
+    const kidVal = JSON.parse(kidRec!.value);
+    expect(kidVal.ran).toBe(ran);
+    expect(kidVal.valid_from).toBe("2026-06-06T00:00:00.000Z");
+  });
+});


### PR DESCRIPTION
## Summary
- `scripts/mint-attestation-kid.py`: mints a hybrid Ed25519 + ML-DSA-65 keypair and the proof-of-possession registration body `register.ts` requires (PQ kept mandatory; private PEMs written mode 0600).
- `functions/v2/keys/[kid].test.ts`: round-trip — a provisioned Ed25519 signature verifies against the served `public_key_pem`, and `/v2/keys/<kid>` returns 200.
- `docs/runbooks/u1b-attestation-registration.md`: mint → register (`wrangler kv bulk put`) → verify → provision → archive. Registers `organization=OpenCastor`, `purpose=attestation`.

## Test Plan
- [x] `npx vitest run` green (mint round-trip 201, runbook KV-record test)
- [x] Minted private keys are mode 0600 (stat-verified)
- [ ] Live: confirm the attestation RAN is free, then `wrangler kv bulk put` to production RRF

⚠️ Open: the runbook example uses `RAN-000000000021`; confirm it's free (may collide with auto-assigned RANs) before live registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
