### PR TITLE
fix(u1b): RRF attestation registration — hybrid mint + register + runbook (review-hardened)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules/
 package-lock.json
 
 .worktrees/
+
+*-private.pem
+mint-manifest.json

--- a/docs/runbooks/u1b-attestation-registration.md
+++ b/docs/runbooks/u1b-attestation-registration.md
@@ -12,11 +12,11 @@ Prereqs:
 - An RRF RAN for this attestation authority (the `--ran` below). NOTE: `register-operator-kid.ts`
   takes an explicit RAN and does NOT use `counter:ran`; pick a RAN that does not collide with any
   existing `authority:RAN-*` and is outside the range `POST /v2/authorities/register` will auto-assign.
-  Confirm it is free:  `wrangler kv key get "authority:RAN-000000000021" --binding RRF_KV --remote`  → expect "key not found".
+  Confirm YOUR chosen RAN is free (the deployed bob-gw-attest-2026 used RAN-000000000777; pick a DIFFERENT free reserved RAN for a new robot):  `wrangler kv key get "authority:<RAN>" --binding RRF_KV --remote`  → expect "key not found".
 
 Choose values (used throughout):
     KID=bob-gw-attest-2026
-    RAN=RAN-000000000021
+    RAN=RAN-000000000777
     REGISTERED_BY=RAN-000000000018
     VALID_FROM=2026-06-06T00:00:00.000Z
     MINT_DIR=~/.opencastor-ops-keys/attestation-2026-06-06
@@ -68,7 +68,7 @@ A 404 → the `kid:*` mapping did not land (re-check step 3). A 502 → byte-len
 Provision out-of-band to the gateway host (never commit these):
     ROBOT_MD_ATTESTATION_KEY_FILE = $MINT_DIR/attestation-ed25519-private.pem
     ROBOT_MD_ATTESTATION_KID      = bob-gw-attest-2026
-    ROBOT_MD_ATTESTATION_RAN      = RAN-000000000021
+    ROBOT_MD_ATTESTATION_RAN      = RAN-000000000777
 The gateway-side loader that reads these env vars is U1a's scope — out of scope here.
 The **public** kid/RAN may live in `OpenCastor/bob-spec-b-pick-place` non-secret config; the
 PEM must NOT (spec §11.1: keys stay in `~/.opencastor-ops-keys`).

--- a/functions/v2/keys/[kid].test.ts
+++ b/functions/v2/keys/[kid].test.ts
@@ -231,7 +231,7 @@ describe("U1b attestation round-trip — provisioned Ed25519 verifies against se
     const ed25519Pub = ed25519.getPublicKey(ed25519Priv);
     const pqPub = crypto.getRandomValues(new Uint8Array(1952));
     const kid = "bob-gw-attest-2026";
-    const ran = "RAN-000000000021";
+    const ran = "RAN-000000000777";
     store[`kid:${kid}:2026-06-06T00:00:00.000Z`] = JSON.stringify({
       ran,
       valid_from: "2026-06-06T00:00:00.000Z",
@@ -297,7 +297,7 @@ describe("U1b attestation round-trip — provisioned Ed25519 verifies against se
     const ed25519Pub = ed25519.getPublicKey(ed25519Priv);
     const pqPub = crypto.getRandomValues(new Uint8Array(1952));
     const kid = "bob-gw-attest-2026";
-    const ran = "RAN-000000000021";
+    const ran = "RAN-000000000777";
     store[`kid:${kid}:2026-06-06T00:00:00.000Z`] = JSON.stringify({
       ran, valid_from: "2026-06-06T00:00:00.000Z",
       registered_at: "2026-06-06T00:00:00.000Z", registered_by: "RAN-000000000018",

--- a/scripts/mint-attestation-kid.py
+++ b/scripts/mint-attestation-kid.py
@@ -35,12 +35,26 @@ def main() -> None:
     ap.add_argument("--display-name", required=True, help="human label for the authority record")
     ap.add_argument("--purpose", default="attestation", help="AuthorityPurpose (default: attestation)")
     ap.add_argument("--out-dir", required=True, help="directory to write the three artifacts into")
+    ap.add_argument("--force", action="store_true", help="overwrite an existing keypair/manifest in --out-dir (default: refuse)")
     args = ap.parse_args()
+    os.umask(0o077)  # private keys: deny group/other from creation (closes the write->chmod window)
 
     out = Path(args.out_dir)
     out.mkdir(parents=True, exist_ok=True)
     # Private signing keys land here; keep the dir owner-only too (best-effort).
     os.chmod(out, 0o700)
+
+    _targets = [
+        out / "attestation-ed25519-private.pem",
+        out / "attestation-mldsa65-private.pem",
+        out / "mint-manifest.json",
+    ]
+    _existing = [p.name for p in _targets if p.exists()]
+    if _existing and not args.force:
+        raise SystemExit(
+            f"refusing to overwrite existing {_existing} in {out} — pass --force to replace "
+            f"(rotation = re-mint with a NEW RAN; see docs/runbooks/u1b-attestation-registration.md)"
+        )
 
     # 1. Ed25519: PKCS8 PEM (gateway), raw 32-byte seed (sign_body), raw 32-byte pub (registered).
     ed = Ed25519PrivateKey.generate()

--- a/tests/u1b-runbook-kv-record.test.ts
+++ b/tests/u1b-runbook-kv-record.test.ts
@@ -18,7 +18,7 @@ describe("U1b runbook — register-operator-kid.ts emits the attestation KV pair
     const m = JSON.parse(readFileSync(join(dir, "mint-manifest.json"), "utf-8"));
 
     const kid = "bob-gw-attest-2026";
-    const ran = "RAN-000000000021";
+    const ran = "RAN-000000000777";
     const stdout = execFileSync("npx", ["tsx", REGISTER,
       "--kid", kid,
       "--ran", ran,


### PR DESCRIPTION
## Summary
**U1b — RRF attestation registration** (the identity leg of the robot→PlatAtlas "U1" loop). Adds the tooling + tests + runbook to mint a hybrid **Ed25519 + ML-DSA-65** attestation keypair, register its `kid` in RRF bound to a GitHub org, and provision **only** the Ed25519 key to the gateway (ML-DSA archived offline). Hybrid is mandatory in RRF (register + serve); the gateway signs Ed25519-only at runtime; PlatAtlas S3 verifies Ed25519 via `/v2/keys/<kid>`.

This is **additive only** (mint script + tests + runbook + `.gitignore`; no change to the `/v2/keys/[kid].ts` serving function).

## Already proven in prod
The attestation kid `bob-gw-attest-2026` (`RAN-000000000777`) is live + active at `https://robotregistryfoundation.org/v2/keys/bob-gw-attest-2026`, and a gateway-signed robot outcome verified end-to-end into PlatAtlas org `opencastor` (`_trust: verified, binding_ok:true`). This PR lands the tooling that produced it.

## Pre-merge review fixes (adversarial review `wmkqyqge9`)
- **RAN collision:** runbook + tests hardcoded `RAN-000000000021`, which is **already occupied** in prod. Replaced with the deployed `RAN-000000000777`; the runbook's "confirm free" step now notes 777 is taken and tells you to pick a fresh reserved RAN for a new robot.
- **Silent clobber:** `mint-attestation-kid.py` overwrote an existing keypair on re-run. Added a `--force` guard (refuses by default) + `os.umask(0o077)` to close the write→chmod window.
- **Defense-in-depth:** `.gitignore` now excludes `*-private.pem` + `mint-manifest.json`.

## Test plan
- [x] `npx vitest run` → **397/397 pass** (incl. the mint round-trip, the runbook KV-record shape, and the `/v2/keys/[kid]` attestation round-trip + tamper tests)
- [x] Clobber guard verified: second `mint` run refuses without `--force`
- [x] `grep RAN-000000000021` → zero remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)
